### PR TITLE
Add optional synced Credentials Provider for native credentials()/withCredentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,32 @@ The following examples demonstrate how to authenticate and retrieve items using 
  
 ---
 
+## Synced Credentials (Credentials Provider) — optional
+
+In addition to classic job binding (`withAkeyless` / Build Wrapper), you can optionally sync Akeyless items into the Jenkins credential store for native use with `credentials('id')` / `withCredentials`.
+
+1. Open **Manage Jenkins → System**.
+2. Find **Akeyless Synced Credentials (Credentials Provider)**.
+3. Set gateway URL, authentication, and folder path / secret paths.
+4. Save, then open **Manage Jenkins → Credentials** and confirm synced items appear under the Akeyless store.
+5. Use them in a pipeline, for example:
+
+```groovy
+withCredentials([string(credentialsId: 'my-secret', variable: 'TOKEN')]) {
+  sh 'echo "secret loaded"'
+}
+```
+
+If this section is left empty, behavior is unchanged: existing freestyle / `withAkeyless` jobs continue to work as before.
+
+### Local build
+
+```bash
+mvn clean package -DskipTests
+```
+
+Install `target/akeyless.hpi` via **Manage Jenkins → Plugins → Advanced → Upload Plugin**.
+
 ## License
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,8 @@
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <spotless.check.skip>false</spotless.check.skip>
+    <!-- Keep spotless off for local merge work; enable before upstream PR -->
+    <spotless.check.skip>true</spotless.check.skip>
   </properties>
 
   <dependencyManagement>
@@ -112,7 +113,19 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials-binding</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>plain-credentials</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>ssh-credentials</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,6 @@
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <!-- Keep spotless off for local merge work; enable before upstream PR -->
-    <spotless.check.skip>true</spotless.check.skip>
   </properties>
 
   <dependencyManagement>
@@ -121,15 +119,15 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>plain-credentials</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-credentials</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>jackson2-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/AkeylessSyncedCredentialsProvider.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/AkeylessSyncedCredentialsProvider.java
@@ -21,9 +21,6 @@ import hudson.security.ACL;
 import hudson.security.ACLContext;
 import io.jenkins.plugins.akeyless.synced.config.AkeylessSyncedCredentialsProviderConfig;
 import io.jenkins.plugins.akeyless.synced.supplier.SyncedCredentialsSupplier;
-import jenkins.model.Jenkins;
-import org.springframework.security.core.Authentication;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -31,6 +28,8 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import jenkins.model.Jenkins;
+import org.springframework.security.core.Authentication;
 
 @Extension
 public class AkeylessSyncedCredentialsProvider extends CredentialsProvider {
@@ -50,10 +49,11 @@ public class AkeylessSyncedCredentialsProvider extends CredentialsProvider {
 
     @NonNull
     @Override
-    public <C extends Credentials> List<C> getCredentialsInItemGroup(@NonNull Class<C> type,
-                                                                     @CheckForNull ItemGroup itemGroup,
-                                                                     @CheckForNull Authentication authentication,
-                                                                     @NonNull List<DomainRequirement> domainRequirements) {
+    public <C extends Credentials> List<C> getCredentialsInItemGroup(
+            @NonNull Class<C> type,
+            @CheckForNull ItemGroup itemGroup,
+            @CheckForNull Authentication authentication,
+            @NonNull List<DomainRequirement> domainRequirements) {
         AkeylessSyncedCredentialsProviderConfig config = AkeylessSyncedCredentialsProviderConfig.get();
         if (config == null || !config.isDiscoveryConfigured()) {
             return Collections.emptyList();
@@ -69,8 +69,7 @@ public class AkeylessSyncedCredentialsProvider extends CredentialsProvider {
         return getGlobalCredentials(type, authentication);
     }
 
-    private static <C extends Credentials> List<C> getGlobalCredentials(
-            Class<C> type, Authentication authentication) {
+    private static <C extends Credentials> List<C> getGlobalCredentials(Class<C> type, Authentication authentication) {
         AkeylessSyncedCredentialsProviderConfig config = AkeylessSyncedCredentialsProviderConfig.get();
         if (config == null || !config.isConfigured()) {
             LOG.log(Level.FINE, "Akeyless Credentials Provider: global auth not configured");
@@ -83,8 +82,7 @@ public class AkeylessSyncedCredentialsProvider extends CredentialsProvider {
         return filterCredentials(type, SyncedCredentialsSupplier.get(config));
     }
 
-    private static <C extends Credentials> List<C> getPerUserCredentials(
-            Class<C> type, Authentication authentication) {
+    private static <C extends Credentials> List<C> getPerUserCredentials(Class<C> type, Authentication authentication) {
         AkeylessSyncedCredentialsProviderConfig config = AkeylessSyncedCredentialsProviderConfig.get();
         if (config == null) {
             return Collections.emptyList();
@@ -132,13 +130,15 @@ public class AkeylessSyncedCredentialsProvider extends CredentialsProvider {
         return User.getById(cause.getUserId(), false);
     }
 
-    private static <C extends Credentials> List<C> filterCredentials(Class<C> type, Collection<StandardCredentials> all) {
+    private static <C extends Credentials> List<C> filterCredentials(
+            Class<C> type, Collection<StandardCredentials> all) {
         List<C> filtered = all.stream()
                 .filter(c -> type.isAssignableFrom(c.getClass()))
                 .map(type::cast)
                 .collect(Collectors.toList());
-        LOG.log(Level.FINE, "Akeyless Credentials Provider: returning {0} credential(s) for type {1}",
-                new Object[]{filtered.size(), type.getSimpleName()});
+        LOG.log(Level.FINE, "Akeyless Credentials Provider: returning {0} credential(s) for type {1}", new Object[] {
+            filtered.size(), type.getSimpleName()
+        });
         return filtered;
     }
 

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/AkeylessSyncedCredentialsProvider.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/AkeylessSyncedCredentialsProvider.java
@@ -1,0 +1,161 @@
+package io.jenkins.plugins.akeyless.synced;
+
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Extension;
+import hudson.model.Cause;
+import hudson.model.Executor;
+import hudson.model.ItemGroup;
+import hudson.model.ModelObject;
+import hudson.model.Queue;
+import hudson.model.Run;
+import hudson.model.User;
+import hudson.security.ACL;
+import hudson.security.ACLContext;
+import io.jenkins.plugins.akeyless.synced.config.AkeylessSyncedCredentialsProviderConfig;
+import io.jenkins.plugins.akeyless.synced.supplier.SyncedCredentialsSupplier;
+import jenkins.model.Jenkins;
+import org.springframework.security.core.Authentication;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+@Extension
+public class AkeylessSyncedCredentialsProvider extends CredentialsProvider {
+
+    private static final Logger LOG = Logger.getLogger(AkeylessSyncedCredentialsProvider.class.getName());
+
+    private static final Set<CredentialsScope> USER_SCOPES = Collections.singleton(CredentialsScope.USER);
+
+    @Override
+    public Set<CredentialsScope> getScopes(ModelObject object) {
+        AkeylessSyncedCredentialsProviderConfig config = AkeylessSyncedCredentialsProviderConfig.get();
+        if (config != null && config.isPerUserAuthentication() && object instanceof User) {
+            return USER_SCOPES;
+        }
+        return super.getScopes(object);
+    }
+
+    @NonNull
+    @Override
+    public <C extends Credentials> List<C> getCredentialsInItemGroup(@NonNull Class<C> type,
+                                                                     @CheckForNull ItemGroup itemGroup,
+                                                                     @CheckForNull Authentication authentication,
+                                                                     @NonNull List<DomainRequirement> domainRequirements) {
+        AkeylessSyncedCredentialsProviderConfig config = AkeylessSyncedCredentialsProviderConfig.get();
+        if (config == null || !config.isDiscoveryConfigured()) {
+            return Collections.emptyList();
+        }
+
+        if (authentication == null) {
+            authentication = ACL.SYSTEM2;
+        }
+
+        if (config.isPerUserAuthentication()) {
+            return getPerUserCredentials(type, authentication);
+        }
+        return getGlobalCredentials(type, authentication);
+    }
+
+    private static <C extends Credentials> List<C> getGlobalCredentials(
+            Class<C> type, Authentication authentication) {
+        AkeylessSyncedCredentialsProviderConfig config = AkeylessSyncedCredentialsProviderConfig.get();
+        if (config == null || !config.isConfigured()) {
+            LOG.log(Level.FINE, "Akeyless Credentials Provider: global auth not configured");
+            return Collections.emptyList();
+        }
+        if (!ACL.SYSTEM2.equals(authentication)
+                && !Jenkins.get().getACL().hasPermission2(authentication, CredentialsProvider.VIEW)) {
+            return Collections.emptyList();
+        }
+        return filterCredentials(type, SyncedCredentialsSupplier.get(config));
+    }
+
+    private static <C extends Credentials> List<C> getPerUserCredentials(
+            Class<C> type, Authentication authentication) {
+        AkeylessSyncedCredentialsProviderConfig config = AkeylessSyncedCredentialsProviderConfig.get();
+        if (config == null) {
+            return Collections.emptyList();
+        }
+
+        User user = User.get2(authentication);
+        if (user == null && ACL.SYSTEM2.equals(authentication)) {
+            user = resolveUserFromBuildContext();
+        }
+        if (user == null) {
+            return Collections.emptyList();
+        }
+
+        User resolvedUser = user;
+        boolean needImpersonation = !resolvedUser.equals(User.current());
+        if (needImpersonation) {
+            try (ACLContext ignored = ACL.as2(resolvedUser.impersonate2())) {
+                return filterCredentials(type, SyncedCredentialsSupplier.get(config, resolvedUser));
+            }
+        }
+        return filterCredentials(type, SyncedCredentialsSupplier.get(config, resolvedUser));
+    }
+
+    /**
+     * When a pipeline runs as SYSTEM but was started by a user, resolve that user from the current {@link Run}.
+     */
+    @Nullable
+    private static User resolveUserFromBuildContext() {
+        User user = User.current();
+        if (user != null) {
+            return user;
+        }
+        Executor executor = Executor.currentExecutor();
+        if (executor == null) {
+            return null;
+        }
+        Queue.Executable executable = executor.getCurrentExecutable();
+        if (!(executable instanceof Run<?, ?> run)) {
+            return null;
+        }
+        Cause.UserIdCause cause = run.getCause(Cause.UserIdCause.class);
+        if (cause == null) {
+            return null;
+        }
+        return User.getById(cause.getUserId(), false);
+    }
+
+    private static <C extends Credentials> List<C> filterCredentials(Class<C> type, Collection<StandardCredentials> all) {
+        List<C> filtered = all.stream()
+                .filter(c -> type.isAssignableFrom(c.getClass()))
+                .map(type::cast)
+                .collect(Collectors.toList());
+        LOG.log(Level.FINE, "Akeyless Credentials Provider: returning {0} credential(s) for type {1}",
+                new Object[]{filtered.size(), type.getSimpleName()});
+        return filtered;
+    }
+
+    @Override
+    public CredentialsStore getStore(ModelObject object) {
+        AkeylessSyncedCredentialsProviderConfig config = AkeylessSyncedCredentialsProviderConfig.get();
+        if (config == null || !config.isDiscoveryConfigured()) {
+            return null;
+        }
+        if (config.isPerUserAuthentication()) {
+            return object instanceof User ? new AkeylessSyncedCredentialsStore(this, (User) object) : null;
+        }
+        return object == Jenkins.get() ? new AkeylessSyncedCredentialsStore(this, null) : null;
+    }
+
+    @Override
+    public String getIconClassName() {
+        return "symbol-akeyless plugin-akeyless";
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/AkeylessSyncedCredentialsStore.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/AkeylessSyncedCredentialsStore.java
@@ -14,11 +14,10 @@ import hudson.security.ACLContext;
 import hudson.security.Permission;
 import io.jenkins.plugins.akeyless.synced.config.AkeylessSyncedCredentialsProviderConfig;
 import io.jenkins.plugins.akeyless.synced.supplier.SyncedCredentialsSupplier;
-import jenkins.model.Jenkins;
-import org.springframework.security.core.Authentication;
-
 import java.util.Collections;
 import java.util.List;
+import jenkins.model.Jenkins;
+import org.springframework.security.core.Authentication;
 
 public class AkeylessSyncedCredentialsStore extends CredentialsStore {
 
@@ -88,7 +87,8 @@ public class AkeylessSyncedCredentialsStore extends CredentialsStore {
     }
 
     @Override
-    public boolean updateCredentials(@NonNull Domain domain, @NonNull Credentials current, @NonNull Credentials replacement) {
+    public boolean updateCredentials(
+            @NonNull Domain domain, @NonNull Credentials current, @NonNull Credentials replacement) {
         throw new UnsupportedOperationException("Jenkins may not update credentials in Akeyless");
     }
 

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/AkeylessSyncedCredentialsStore.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/AkeylessSyncedCredentialsStore.java
@@ -1,0 +1,143 @@
+package io.jenkins.plugins.akeyless.synced;
+
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.CredentialsStoreAction;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.model.ModelObject;
+import hudson.model.User;
+import hudson.security.ACL;
+import hudson.security.ACLContext;
+import hudson.security.Permission;
+import io.jenkins.plugins.akeyless.synced.config.AkeylessSyncedCredentialsProviderConfig;
+import io.jenkins.plugins.akeyless.synced.supplier.SyncedCredentialsSupplier;
+import jenkins.model.Jenkins;
+import org.springframework.security.core.Authentication;
+
+import java.util.Collections;
+import java.util.List;
+
+public class AkeylessSyncedCredentialsStore extends CredentialsStore {
+
+    private final AkeylessSyncedCredentialsProvider provider;
+
+    @Nullable
+    private final User owner;
+
+    /** One action per store instance so {@link CredentialsStoreAction#isVisible()} identity checks match the bound URL action. */
+    private transient CredentialsStoreAction storeAction;
+
+    public AkeylessSyncedCredentialsStore(AkeylessSyncedCredentialsProvider provider, @Nullable User owner) {
+        super(AkeylessSyncedCredentialsProvider.class);
+        this.provider = provider;
+        this.owner = owner;
+    }
+
+    @NonNull
+    @Override
+    public ModelObject getContext() {
+        return owner != null ? owner : Jenkins.get();
+    }
+
+    @Override
+    public boolean hasPermission2(@NonNull Authentication authentication, @NonNull Permission permission) {
+        if (!CredentialsProvider.VIEW.equals(permission)) {
+            return false;
+        }
+        if (owner != null) {
+            return owner.getACL().hasPermission2(authentication, permission);
+        }
+        return Jenkins.get().getACL().hasPermission2(authentication, permission);
+    }
+
+    @NonNull
+    @Override
+    public List<Credentials> getCredentials(@NonNull Domain domain) {
+        if (!Domain.global().equals(domain)) {
+            return Collections.emptyList();
+        }
+        if (owner != null) {
+            if (!owner.hasPermission(CredentialsProvider.VIEW)) {
+                return Collections.emptyList();
+            }
+            AkeylessSyncedCredentialsProviderConfig config = AkeylessSyncedCredentialsProviderConfig.get();
+            if (config == null) {
+                return Collections.emptyList();
+            }
+            try (ACLContext ignored = ACL.as2(owner.impersonate2())) {
+                return List.copyOf(SyncedCredentialsSupplier.get(config, owner));
+            }
+        }
+        if (Jenkins.get().hasPermission(CredentialsProvider.VIEW)) {
+            return provider.getCredentialsInItemGroup(Credentials.class, Jenkins.get(), ACL.SYSTEM2, List.of());
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean addCredentials(@NonNull Domain domain, @NonNull Credentials credentials) {
+        throw new UnsupportedOperationException("Jenkins may not add credentials to Akeyless");
+    }
+
+    @Override
+    public boolean removeCredentials(@NonNull Domain domain, @NonNull Credentials credentials) {
+        throw new UnsupportedOperationException("Jenkins may not remove credentials from Akeyless");
+    }
+
+    @Override
+    public boolean updateCredentials(@NonNull Domain domain, @NonNull Credentials current, @NonNull Credentials replacement) {
+        throw new UnsupportedOperationException("Jenkins may not update credentials in Akeyless");
+    }
+
+    @Nullable
+    @Override
+    public synchronized CredentialsStoreAction getStoreAction() {
+        if (storeAction == null) {
+            storeAction = new AkeylessCredentialsStoreAction(this);
+        }
+        return storeAction;
+    }
+
+    /** Read-only Akeyless-backed store listing; visibility does not depend on Jenkins “add credential” descriptors. */
+    public static class AkeylessCredentialsStoreAction extends CredentialsStoreAction {
+
+        private final AkeylessSyncedCredentialsStore store;
+
+        public AkeylessCredentialsStoreAction(AkeylessSyncedCredentialsStore store) {
+            this.store = store;
+        }
+
+        @Override
+        @NonNull
+        public CredentialsStore getStore() {
+            return store;
+        }
+
+        @Override
+        public boolean isVisible() {
+            CredentialsProvider p = store.getProvider();
+            if (p == null || !p.isEnabled()) {
+                return false;
+            }
+            return store.hasPermission(CredentialsProvider.VIEW);
+        }
+
+        @Override
+        public String getIconFileName() {
+            return null;
+        }
+
+        @Override
+        public String getIconClassName() {
+            return isVisible() ? "symbol-akeyless plugin-akeyless" : null;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.AkeylessSyncedCredentialsProvider_DisplayName();
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/auth/ApiKeySyncedAuthMethod.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/auth/ApiKeySyncedAuthMethod.java
@@ -1,0 +1,62 @@
+package io.jenkins.plugins.akeyless.synced.auth;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.util.Secret;
+import io.akeyless.client.model.Auth;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nullable;
+
+public class ApiKeySyncedAuthMethod extends SyncedAuthMethod {
+
+    private Secret accessKey;
+
+    @DataBoundConstructor
+    public ApiKeySyncedAuthMethod() {}
+
+    public Secret getAccessKey() { return accessKey; }
+
+    @DataBoundSetter
+    public void setAccessKey(Secret accessKey) { this.accessKey = accessKey; }
+
+    @Override
+    public Auth buildAuth(@Nullable String accessId) {
+        Auth auth = new Auth();
+        auth.setAccessId(trimCopyPasted(accessId));
+        auth.setAccessKey(normalizeAccessKey(Secret.toString(accessKey)));
+        return auth;
+    }
+
+    @Override
+    public boolean isConfigured(@Nullable String accessId) {
+        String id = trimCopyPasted(accessId);
+        if (id == null || id.isBlank() || accessKey == null) {
+            return false;
+        }
+        return !normalizeAccessKey(Secret.toString(accessKey)).isBlank();
+    }
+
+    /** Trims the access id; Akeyless rejects auth when the id contains accidental spaces. */
+    private static String trimCopyPasted(@Nullable String s) {
+        return s == null ? null : s.trim();
+    }
+
+    /**
+     * Akeyless decodes the access key as Base64 on the gateway. Remove all whitespace so line-wrapped or
+     * copy-pasted keys still decode; trim ends so stray newlines do not break decoding.
+     */
+    private static String normalizeAccessKey(String raw) {
+        if (raw == null) {
+            return "";
+        }
+        return raw.trim().replaceAll("\\s+", "");
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<SyncedAuthMethod> {
+        @Override
+        public String getDisplayName() { return "API Key"; }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/auth/ApiKeySyncedAuthMethod.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/auth/ApiKeySyncedAuthMethod.java
@@ -4,10 +4,9 @@ import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.util.Secret;
 import io.akeyless.client.model.Auth;
+import javax.annotation.Nullable;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
-
-import javax.annotation.Nullable;
 
 public class ApiKeySyncedAuthMethod extends SyncedAuthMethod {
 
@@ -16,10 +15,14 @@ public class ApiKeySyncedAuthMethod extends SyncedAuthMethod {
     @DataBoundConstructor
     public ApiKeySyncedAuthMethod() {}
 
-    public Secret getAccessKey() { return accessKey; }
+    public Secret getAccessKey() {
+        return accessKey;
+    }
 
     @DataBoundSetter
-    public void setAccessKey(Secret accessKey) { this.accessKey = accessKey; }
+    public void setAccessKey(Secret accessKey) {
+        this.accessKey = accessKey;
+    }
 
     @Override
     public Auth buildAuth(@Nullable String accessId) {
@@ -57,6 +60,8 @@ public class ApiKeySyncedAuthMethod extends SyncedAuthMethod {
     @Extension
     public static class DescriptorImpl extends Descriptor<SyncedAuthMethod> {
         @Override
-        public String getDisplayName() { return "API Key"; }
+        public String getDisplayName() {
+            return "API Key";
+        }
     }
 }

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/auth/AwsIamSyncedAuthMethod.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/auth/AwsIamSyncedAuthMethod.java
@@ -1,0 +1,56 @@
+package io.jenkins.plugins.akeyless.synced.auth;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import io.akeyless.client.model.Auth;
+import io.jenkins.plugins.akeyless.cloudid.CloudIdProvider;
+import io.jenkins.plugins.akeyless.cloudid.CloudProviderFactory;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nullable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * AWS IAM authentication. Obtains cloud identity from EC2/ECS/env (SigV4-signed STS GetCallerIdentity).
+ */
+public class AwsIamSyncedAuthMethod extends SyncedAuthMethod {
+
+    private static final Logger LOG = Logger.getLogger(AwsIamSyncedAuthMethod.class.getName());
+    private static final String ACCESS_TYPE = "aws_iam";
+
+    @DataBoundConstructor
+    public AwsIamSyncedAuthMethod() {}
+
+    @Override
+    public Auth buildAuth(@Nullable String accessId) throws Exception {
+        LOG.log(Level.INFO, "Akeyless AWS IAM auth: building auth for access_id={0}", accessId);
+        String cloudId;
+        try {
+            CloudIdProvider idProvider = CloudProviderFactory.getCloudIdProvider(ACCESS_TYPE);
+            cloudId = idProvider.getCloudId();
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Failed to generate AWS cloud ID", e);
+            throw new Exception("AWS IAM auth: could not obtain cloud identity. "
+                    + "Ensure Jenkins is running on AWS with an IAM role attached. " + e.getMessage(), e);
+        }
+        Auth auth = new Auth();
+        auth.setAccessId(accessId);
+        auth.setAccessType(ACCESS_TYPE);
+        auth.setCloudId(cloudId);
+        LOG.log(Level.INFO, "Akeyless AWS IAM auth: sending auth request (access_id={0}, cloud_id_length={1})",
+                new Object[]{accessId, cloudId.length()});
+        return auth;
+    }
+
+    @Override
+    public boolean isConfigured(@Nullable String accessId) {
+        return accessId != null && !accessId.isBlank();
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<SyncedAuthMethod> {
+        @Override
+        public String getDisplayName() { return "AWS IAM"; }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/auth/AwsIamSyncedAuthMethod.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/auth/AwsIamSyncedAuthMethod.java
@@ -5,11 +5,10 @@ import hudson.model.Descriptor;
 import io.akeyless.client.model.Auth;
 import io.jenkins.plugins.akeyless.cloudid.CloudIdProvider;
 import io.jenkins.plugins.akeyless.cloudid.CloudProviderFactory;
-import org.kohsuke.stapler.DataBoundConstructor;
-
-import javax.annotation.Nullable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * AWS IAM authentication. Obtains cloud identity from EC2/ECS/env (SigV4-signed STS GetCallerIdentity).
@@ -31,15 +30,19 @@ public class AwsIamSyncedAuthMethod extends SyncedAuthMethod {
             cloudId = idProvider.getCloudId();
         } catch (Exception e) {
             LOG.log(Level.SEVERE, "Failed to generate AWS cloud ID", e);
-            throw new Exception("AWS IAM auth: could not obtain cloud identity. "
-                    + "Ensure Jenkins is running on AWS with an IAM role attached. " + e.getMessage(), e);
+            throw new Exception(
+                    "AWS IAM auth: could not obtain cloud identity. "
+                            + "Ensure Jenkins is running on AWS with an IAM role attached. " + e.getMessage(),
+                    e);
         }
         Auth auth = new Auth();
         auth.setAccessId(accessId);
         auth.setAccessType(ACCESS_TYPE);
         auth.setCloudId(cloudId);
-        LOG.log(Level.INFO, "Akeyless AWS IAM auth: sending auth request (access_id={0}, cloud_id_length={1})",
-                new Object[]{accessId, cloudId.length()});
+        LOG.log(
+                Level.INFO,
+                "Akeyless AWS IAM auth: sending auth request (access_id={0}, cloud_id_length={1})",
+                new Object[] {accessId, cloudId.length()});
         return auth;
     }
 
@@ -51,6 +54,8 @@ public class AwsIamSyncedAuthMethod extends SyncedAuthMethod {
     @Extension
     public static class DescriptorImpl extends Descriptor<SyncedAuthMethod> {
         @Override
-        public String getDisplayName() { return "AWS IAM"; }
+        public String getDisplayName() {
+            return "AWS IAM";
+        }
     }
 }

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/auth/AzureAdSyncedAuthMethod.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/auth/AzureAdSyncedAuthMethod.java
@@ -1,0 +1,54 @@
+package io.jenkins.plugins.akeyless.synced.auth;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import io.akeyless.client.model.Auth;
+import io.jenkins.plugins.akeyless.cloudid.CloudIdProvider;
+import io.jenkins.plugins.akeyless.cloudid.CloudProviderFactory;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nullable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Azure AD authentication. Uses akeyless-java-cloud-id-lightweight to obtain
+ * Managed Identity token from Azure IMDS.
+ */
+public class AzureAdSyncedAuthMethod extends SyncedAuthMethod {
+
+    private static final Logger LOG = Logger.getLogger(AzureAdSyncedAuthMethod.class.getName());
+    private static final String ACCESS_TYPE = "azure_ad";
+
+    @DataBoundConstructor
+    public AzureAdSyncedAuthMethod() {}
+
+    @Override
+    public Auth buildAuth(@Nullable String accessId) throws Exception {
+        String cloudId;
+        try {
+            CloudIdProvider idProvider = CloudProviderFactory.getCloudIdProvider(ACCESS_TYPE);
+            cloudId = idProvider.getCloudId();
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Failed to generate Azure cloud ID from IMDS", e);
+            throw new Exception("Azure AD auth: could not obtain cloud identity. "
+                    + "Ensure Jenkins is running on Azure with a managed identity. " + e.getMessage(), e);
+        }
+        Auth auth = new Auth();
+        auth.setAccessId(accessId);
+        auth.setAccessType(ACCESS_TYPE);
+        auth.setCloudId(cloudId);
+        return auth;
+    }
+
+    @Override
+    public boolean isConfigured(@Nullable String accessId) {
+        return accessId != null && !accessId.isBlank();
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<SyncedAuthMethod> {
+        @Override
+        public String getDisplayName() { return "Azure AD"; }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/auth/AzureAdSyncedAuthMethod.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/auth/AzureAdSyncedAuthMethod.java
@@ -5,11 +5,10 @@ import hudson.model.Descriptor;
 import io.akeyless.client.model.Auth;
 import io.jenkins.plugins.akeyless.cloudid.CloudIdProvider;
 import io.jenkins.plugins.akeyless.cloudid.CloudProviderFactory;
-import org.kohsuke.stapler.DataBoundConstructor;
-
-import javax.annotation.Nullable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * Azure AD authentication. Uses akeyless-java-cloud-id-lightweight to obtain
@@ -31,8 +30,10 @@ public class AzureAdSyncedAuthMethod extends SyncedAuthMethod {
             cloudId = idProvider.getCloudId();
         } catch (Exception e) {
             LOG.log(Level.SEVERE, "Failed to generate Azure cloud ID from IMDS", e);
-            throw new Exception("Azure AD auth: could not obtain cloud identity. "
-                    + "Ensure Jenkins is running on Azure with a managed identity. " + e.getMessage(), e);
+            throw new Exception(
+                    "Azure AD auth: could not obtain cloud identity. "
+                            + "Ensure Jenkins is running on Azure with a managed identity. " + e.getMessage(),
+                    e);
         }
         Auth auth = new Auth();
         auth.setAccessId(accessId);
@@ -49,6 +50,8 @@ public class AzureAdSyncedAuthMethod extends SyncedAuthMethod {
     @Extension
     public static class DescriptorImpl extends Descriptor<SyncedAuthMethod> {
         @Override
-        public String getDisplayName() { return "Azure AD"; }
+        public String getDisplayName() {
+            return "Azure AD";
+        }
     }
 }

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/auth/CertificateSyncedAuthMethod.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/auth/CertificateSyncedAuthMethod.java
@@ -1,0 +1,55 @@
+package io.jenkins.plugins.akeyless.synced.auth;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.util.Secret;
+import io.akeyless.client.model.Auth;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nullable;
+
+/**
+ * Certificate-based authentication with Akeyless.
+ * Requires the certificate data (PEM) and private key data (PEM), both stored encrypted.
+ */
+public class CertificateSyncedAuthMethod extends SyncedAuthMethod {
+
+    private Secret certData;
+    private Secret keyData;
+
+    @DataBoundConstructor
+    public CertificateSyncedAuthMethod() {}
+
+    public Secret getCertData() { return certData; }
+
+    @DataBoundSetter
+    public void setCertData(Secret certData) { this.certData = certData; }
+
+    public Secret getKeyData() { return keyData; }
+
+    @DataBoundSetter
+    public void setKeyData(Secret keyData) { this.keyData = keyData; }
+
+    @Override
+    public Auth buildAuth(@Nullable String accessId) {
+        Auth auth = new Auth();
+        auth.setAccessId(accessId);
+        auth.setCertData(Secret.toString(certData));
+        auth.setKeyData(Secret.toString(keyData));
+        return auth;
+    }
+
+    @Override
+    public boolean isConfigured(@Nullable String accessId) {
+        return accessId != null && !accessId.isBlank()
+                && certData != null && !Secret.toString(certData).isBlank()
+                && keyData != null && !Secret.toString(keyData).isBlank();
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<SyncedAuthMethod> {
+        @Override
+        public String getDisplayName() { return "Certificate"; }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/auth/CertificateSyncedAuthMethod.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/auth/CertificateSyncedAuthMethod.java
@@ -4,10 +4,9 @@ import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.util.Secret;
 import io.akeyless.client.model.Auth;
+import javax.annotation.Nullable;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
-
-import javax.annotation.Nullable;
 
 /**
  * Certificate-based authentication with Akeyless.
@@ -21,15 +20,23 @@ public class CertificateSyncedAuthMethod extends SyncedAuthMethod {
     @DataBoundConstructor
     public CertificateSyncedAuthMethod() {}
 
-    public Secret getCertData() { return certData; }
+    public Secret getCertData() {
+        return certData;
+    }
 
     @DataBoundSetter
-    public void setCertData(Secret certData) { this.certData = certData; }
+    public void setCertData(Secret certData) {
+        this.certData = certData;
+    }
 
-    public Secret getKeyData() { return keyData; }
+    public Secret getKeyData() {
+        return keyData;
+    }
 
     @DataBoundSetter
-    public void setKeyData(Secret keyData) { this.keyData = keyData; }
+    public void setKeyData(Secret keyData) {
+        this.keyData = keyData;
+    }
 
     @Override
     public Auth buildAuth(@Nullable String accessId) {
@@ -42,14 +49,19 @@ public class CertificateSyncedAuthMethod extends SyncedAuthMethod {
 
     @Override
     public boolean isConfigured(@Nullable String accessId) {
-        return accessId != null && !accessId.isBlank()
-                && certData != null && !Secret.toString(certData).isBlank()
-                && keyData != null && !Secret.toString(keyData).isBlank();
+        return accessId != null
+                && !accessId.isBlank()
+                && certData != null
+                && !Secret.toString(certData).isBlank()
+                && keyData != null
+                && !Secret.toString(keyData).isBlank();
     }
 
     @Extension
     public static class DescriptorImpl extends Descriptor<SyncedAuthMethod> {
         @Override
-        public String getDisplayName() { return "Certificate"; }
+        public String getDisplayName() {
+            return "Certificate";
+        }
     }
 }

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/auth/EmailSyncedAuthMethod.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/auth/EmailSyncedAuthMethod.java
@@ -4,10 +4,9 @@ import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.util.Secret;
 import io.akeyless.client.model.Auth;
+import javax.annotation.Nullable;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
-
-import javax.annotation.Nullable;
 
 /**
  * Email/password authentication with Akeyless.
@@ -21,15 +20,23 @@ public class EmailSyncedAuthMethod extends SyncedAuthMethod {
     @DataBoundConstructor
     public EmailSyncedAuthMethod() {}
 
-    public String getAdminEmail() { return adminEmail; }
+    public String getAdminEmail() {
+        return adminEmail;
+    }
 
     @DataBoundSetter
-    public void setAdminEmail(String adminEmail) { this.adminEmail = adminEmail; }
+    public void setAdminEmail(String adminEmail) {
+        this.adminEmail = adminEmail;
+    }
 
-    public Secret getAdminPassword() { return adminPassword; }
+    public Secret getAdminPassword() {
+        return adminPassword;
+    }
 
     @DataBoundSetter
-    public void setAdminPassword(Secret adminPassword) { this.adminPassword = adminPassword; }
+    public void setAdminPassword(Secret adminPassword) {
+        this.adminPassword = adminPassword;
+    }
 
     @Override
     public Auth buildAuth(@Nullable String accessId) {
@@ -41,13 +48,17 @@ public class EmailSyncedAuthMethod extends SyncedAuthMethod {
 
     @Override
     public boolean isConfigured(@Nullable String accessId) {
-        return adminEmail != null && !adminEmail.isBlank()
-                && adminPassword != null && !Secret.toString(adminPassword).isBlank();
+        return adminEmail != null
+                && !adminEmail.isBlank()
+                && adminPassword != null
+                && !Secret.toString(adminPassword).isBlank();
     }
 
     @Extension
     public static class DescriptorImpl extends Descriptor<SyncedAuthMethod> {
         @Override
-        public String getDisplayName() { return "Email"; }
+        public String getDisplayName() {
+            return "Email";
+        }
     }
 }

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/auth/EmailSyncedAuthMethod.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/auth/EmailSyncedAuthMethod.java
@@ -1,0 +1,53 @@
+package io.jenkins.plugins.akeyless.synced.auth;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.util.Secret;
+import io.akeyless.client.model.Auth;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nullable;
+
+/**
+ * Email/password authentication with Akeyless.
+ * Does not require an Access ID — uses admin email and password directly.
+ */
+public class EmailSyncedAuthMethod extends SyncedAuthMethod {
+
+    private String adminEmail;
+    private Secret adminPassword;
+
+    @DataBoundConstructor
+    public EmailSyncedAuthMethod() {}
+
+    public String getAdminEmail() { return adminEmail; }
+
+    @DataBoundSetter
+    public void setAdminEmail(String adminEmail) { this.adminEmail = adminEmail; }
+
+    public Secret getAdminPassword() { return adminPassword; }
+
+    @DataBoundSetter
+    public void setAdminPassword(Secret adminPassword) { this.adminPassword = adminPassword; }
+
+    @Override
+    public Auth buildAuth(@Nullable String accessId) {
+        Auth auth = new Auth();
+        auth.setAdminEmail(adminEmail);
+        auth.setAdminPassword(Secret.toString(adminPassword));
+        return auth;
+    }
+
+    @Override
+    public boolean isConfigured(@Nullable String accessId) {
+        return adminEmail != null && !adminEmail.isBlank()
+                && adminPassword != null && !Secret.toString(adminPassword).isBlank();
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<SyncedAuthMethod> {
+        @Override
+        public String getDisplayName() { return "Email"; }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/auth/GcpSyncedAuthMethod.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/auth/GcpSyncedAuthMethod.java
@@ -1,0 +1,65 @@
+package io.jenkins.plugins.akeyless.synced.auth;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import io.akeyless.client.model.Auth;
+import io.jenkins.plugins.akeyless.cloudid.CloudIdProvider;
+import io.jenkins.plugins.akeyless.cloudid.CloudProviderFactory;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nullable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * GCP authentication. Uses akeyless-java-cloud-id-lightweight to obtain
+ * identity token from GCP metadata server.
+ */
+public class GcpSyncedAuthMethod extends SyncedAuthMethod {
+
+    private static final Logger LOG = Logger.getLogger(GcpSyncedAuthMethod.class.getName());
+    private static final String ACCESS_TYPE = "gcp";
+
+    private String gcpAudience;
+
+    @DataBoundConstructor
+    public GcpSyncedAuthMethod() {}
+
+    public String getGcpAudience() { return gcpAudience; }
+
+    @DataBoundSetter
+    public void setGcpAudience(String gcpAudience) { this.gcpAudience = gcpAudience; }
+
+    @Override
+    public Auth buildAuth(@Nullable String accessId) throws Exception {
+        String cloudId;
+        try {
+            CloudIdProvider idProvider = CloudProviderFactory.getCloudIdProvider(ACCESS_TYPE);
+            cloudId = idProvider.getCloudId();
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Failed to generate GCP cloud ID from metadata", e);
+            throw new Exception("GCP auth: could not obtain cloud identity. "
+                    + "Ensure Jenkins is running on GCP with a service account. " + e.getMessage(), e);
+        }
+        Auth auth = new Auth();
+        auth.setAccessId(accessId);
+        auth.setAccessType(ACCESS_TYPE);
+        auth.setCloudId(cloudId);
+        if (gcpAudience != null && !gcpAudience.isBlank()) {
+            auth.setGcpAudience(gcpAudience);
+        }
+        return auth;
+    }
+
+    @Override
+    public boolean isConfigured(@Nullable String accessId) {
+        return accessId != null && !accessId.isBlank();
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<SyncedAuthMethod> {
+        @Override
+        public String getDisplayName() { return "Google Cloud (GCP)"; }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/auth/GcpSyncedAuthMethod.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/auth/GcpSyncedAuthMethod.java
@@ -5,12 +5,11 @@ import hudson.model.Descriptor;
 import io.akeyless.client.model.Auth;
 import io.jenkins.plugins.akeyless.cloudid.CloudIdProvider;
 import io.jenkins.plugins.akeyless.cloudid.CloudProviderFactory;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
-
-import javax.annotation.Nullable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * GCP authentication. Uses akeyless-java-cloud-id-lightweight to obtain
@@ -26,10 +25,14 @@ public class GcpSyncedAuthMethod extends SyncedAuthMethod {
     @DataBoundConstructor
     public GcpSyncedAuthMethod() {}
 
-    public String getGcpAudience() { return gcpAudience; }
+    public String getGcpAudience() {
+        return gcpAudience;
+    }
 
     @DataBoundSetter
-    public void setGcpAudience(String gcpAudience) { this.gcpAudience = gcpAudience; }
+    public void setGcpAudience(String gcpAudience) {
+        this.gcpAudience = gcpAudience;
+    }
 
     @Override
     public Auth buildAuth(@Nullable String accessId) throws Exception {
@@ -39,8 +42,10 @@ public class GcpSyncedAuthMethod extends SyncedAuthMethod {
             cloudId = idProvider.getCloudId();
         } catch (Exception e) {
             LOG.log(Level.SEVERE, "Failed to generate GCP cloud ID from metadata", e);
-            throw new Exception("GCP auth: could not obtain cloud identity. "
-                    + "Ensure Jenkins is running on GCP with a service account. " + e.getMessage(), e);
+            throw new Exception(
+                    "GCP auth: could not obtain cloud identity. "
+                            + "Ensure Jenkins is running on GCP with a service account. " + e.getMessage(),
+                    e);
         }
         Auth auth = new Auth();
         auth.setAccessId(accessId);
@@ -60,6 +65,8 @@ public class GcpSyncedAuthMethod extends SyncedAuthMethod {
     @Extension
     public static class DescriptorImpl extends Descriptor<SyncedAuthMethod> {
         @Override
-        public String getDisplayName() { return "Google Cloud (GCP)"; }
+        public String getDisplayName() {
+            return "Google Cloud (GCP)";
+        }
     }
 }

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/auth/KubernetesSyncedAuthMethod.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/auth/KubernetesSyncedAuthMethod.java
@@ -3,14 +3,13 @@ package io.jenkins.plugins.akeyless.synced.auth;
 import hudson.Extension;
 import hudson.model.Descriptor;
 import io.akeyless.client.model.Auth;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
-
-import javax.annotation.Nullable;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * Kubernetes authentication with Akeyless.
@@ -27,15 +26,23 @@ public class KubernetesSyncedAuthMethod extends SyncedAuthMethod {
     @DataBoundConstructor
     public KubernetesSyncedAuthMethod() {}
 
-    public String getK8sAuthConfigName() { return k8sAuthConfigName; }
+    public String getK8sAuthConfigName() {
+        return k8sAuthConfigName;
+    }
 
     @DataBoundSetter
-    public void setK8sAuthConfigName(String k8sAuthConfigName) { this.k8sAuthConfigName = k8sAuthConfigName; }
+    public void setK8sAuthConfigName(String k8sAuthConfigName) {
+        this.k8sAuthConfigName = k8sAuthConfigName;
+    }
 
-    public String getK8sServiceAccountToken() { return k8sServiceAccountToken; }
+    public String getK8sServiceAccountToken() {
+        return k8sServiceAccountToken;
+    }
 
     @DataBoundSetter
-    public void setK8sServiceAccountToken(String k8sServiceAccountToken) { this.k8sServiceAccountToken = k8sServiceAccountToken; }
+    public void setK8sServiceAccountToken(String k8sServiceAccountToken) {
+        this.k8sServiceAccountToken = k8sServiceAccountToken;
+    }
 
     @Override
     public Auth buildAuth(@Nullable String accessId) throws Exception {
@@ -46,8 +53,8 @@ public class KubernetesSyncedAuthMethod extends SyncedAuthMethod {
                 saToken = Files.readString(p).trim();
                 LOG.log(Level.FINE, "Read Kubernetes service account token from {0}", SA_TOKEN_PATH);
             } else {
-                throw new Exception("Kubernetes auth: no service account token provided "
-                        + "and " + SA_TOKEN_PATH + " is not readable");
+                throw new Exception("Kubernetes auth: no service account token provided " + "and " + SA_TOKEN_PATH
+                        + " is not readable");
             }
         }
         Auth auth = new Auth();
@@ -60,13 +67,14 @@ public class KubernetesSyncedAuthMethod extends SyncedAuthMethod {
 
     @Override
     public boolean isConfigured(@Nullable String accessId) {
-        return accessId != null && !accessId.isBlank()
-                && k8sAuthConfigName != null && !k8sAuthConfigName.isBlank();
+        return accessId != null && !accessId.isBlank() && k8sAuthConfigName != null && !k8sAuthConfigName.isBlank();
     }
 
     @Extension
     public static class DescriptorImpl extends Descriptor<SyncedAuthMethod> {
         @Override
-        public String getDisplayName() { return "Kubernetes"; }
+        public String getDisplayName() {
+            return "Kubernetes";
+        }
     }
 }

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/auth/KubernetesSyncedAuthMethod.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/auth/KubernetesSyncedAuthMethod.java
@@ -1,0 +1,72 @@
+package io.jenkins.plugins.akeyless.synced.auth;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import io.akeyless.client.model.Auth;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nullable;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Kubernetes authentication with Akeyless.
+ * Reads the pod service-account token automatically if not provided manually.
+ */
+public class KubernetesSyncedAuthMethod extends SyncedAuthMethod {
+
+    private static final Logger LOG = Logger.getLogger(KubernetesSyncedAuthMethod.class.getName());
+    private static final String SA_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token";
+
+    private String k8sAuthConfigName;
+    private String k8sServiceAccountToken;
+
+    @DataBoundConstructor
+    public KubernetesSyncedAuthMethod() {}
+
+    public String getK8sAuthConfigName() { return k8sAuthConfigName; }
+
+    @DataBoundSetter
+    public void setK8sAuthConfigName(String k8sAuthConfigName) { this.k8sAuthConfigName = k8sAuthConfigName; }
+
+    public String getK8sServiceAccountToken() { return k8sServiceAccountToken; }
+
+    @DataBoundSetter
+    public void setK8sServiceAccountToken(String k8sServiceAccountToken) { this.k8sServiceAccountToken = k8sServiceAccountToken; }
+
+    @Override
+    public Auth buildAuth(@Nullable String accessId) throws Exception {
+        String saToken = k8sServiceAccountToken;
+        if (saToken == null || saToken.isBlank()) {
+            Path p = Path.of(SA_TOKEN_PATH);
+            if (Files.isReadable(p)) {
+                saToken = Files.readString(p).trim();
+                LOG.log(Level.FINE, "Read Kubernetes service account token from {0}", SA_TOKEN_PATH);
+            } else {
+                throw new Exception("Kubernetes auth: no service account token provided "
+                        + "and " + SA_TOKEN_PATH + " is not readable");
+            }
+        }
+        Auth auth = new Auth();
+        auth.setAccessId(accessId);
+        auth.setAccessType("k8s");
+        auth.setK8sAuthConfigName(k8sAuthConfigName);
+        auth.setK8sServiceAccountToken(saToken);
+        return auth;
+    }
+
+    @Override
+    public boolean isConfigured(@Nullable String accessId) {
+        return accessId != null && !accessId.isBlank()
+                && k8sAuthConfigName != null && !k8sAuthConfigName.isBlank();
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<SyncedAuthMethod> {
+        @Override
+        public String getDisplayName() { return "Kubernetes"; }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/auth/SyncedAuthMethod.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/auth/SyncedAuthMethod.java
@@ -1,0 +1,20 @@
+package io.jenkins.plugins.akeyless.synced.auth;
+
+import hudson.DescriptorExtensionList;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import io.akeyless.client.model.Auth;
+import jenkins.model.Jenkins;
+
+import javax.annotation.Nullable;
+
+public abstract class SyncedAuthMethod extends AbstractDescribableImpl<SyncedAuthMethod> {
+
+    public abstract Auth buildAuth(@Nullable String accessId) throws Exception;
+
+    public abstract boolean isConfigured(@Nullable String accessId);
+
+    public static DescriptorExtensionList<SyncedAuthMethod, Descriptor<SyncedAuthMethod>> all() {
+        return Jenkins.get().getDescriptorList(SyncedAuthMethod.class);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/auth/SyncedAuthMethod.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/auth/SyncedAuthMethod.java
@@ -4,9 +4,8 @@ import hudson.DescriptorExtensionList;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import io.akeyless.client.model.Auth;
-import jenkins.model.Jenkins;
-
 import javax.annotation.Nullable;
+import jenkins.model.Jenkins;
 
 public abstract class SyncedAuthMethod extends AbstractDescribableImpl<SyncedAuthMethod> {
 

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/auth/UniversalIdentitySyncedAuthMethod.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/auth/UniversalIdentitySyncedAuthMethod.java
@@ -1,0 +1,47 @@
+package io.jenkins.plugins.akeyless.synced.auth;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.util.Secret;
+import io.akeyless.client.model.Auth;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nullable;
+
+/**
+ * Universal Identity authentication with Akeyless.
+ */
+public class UniversalIdentitySyncedAuthMethod extends SyncedAuthMethod {
+
+    private Secret uidToken;
+
+    @DataBoundConstructor
+    public UniversalIdentitySyncedAuthMethod() {}
+
+    public Secret getUidToken() { return uidToken; }
+
+    @DataBoundSetter
+    public void setUidToken(Secret uidToken) { this.uidToken = uidToken; }
+
+    @Override
+    public Auth buildAuth(@Nullable String accessId) {
+        Auth auth = new Auth();
+        auth.setAccessId(accessId);
+        auth.setAccessType("universal_identity");
+        auth.setUidToken(Secret.toString(uidToken));
+        return auth;
+    }
+
+    @Override
+    public boolean isConfigured(@Nullable String accessId) {
+        return accessId != null && !accessId.isBlank()
+                && uidToken != null && !Secret.toString(uidToken).isBlank();
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<SyncedAuthMethod> {
+        @Override
+        public String getDisplayName() { return "Universal Identity"; }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/auth/UniversalIdentitySyncedAuthMethod.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/auth/UniversalIdentitySyncedAuthMethod.java
@@ -4,10 +4,9 @@ import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.util.Secret;
 import io.akeyless.client.model.Auth;
+import javax.annotation.Nullable;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
-
-import javax.annotation.Nullable;
 
 /**
  * Universal Identity authentication with Akeyless.
@@ -19,10 +18,14 @@ public class UniversalIdentitySyncedAuthMethod extends SyncedAuthMethod {
     @DataBoundConstructor
     public UniversalIdentitySyncedAuthMethod() {}
 
-    public Secret getUidToken() { return uidToken; }
+    public Secret getUidToken() {
+        return uidToken;
+    }
 
     @DataBoundSetter
-    public void setUidToken(Secret uidToken) { this.uidToken = uidToken; }
+    public void setUidToken(Secret uidToken) {
+        this.uidToken = uidToken;
+    }
 
     @Override
     public Auth buildAuth(@Nullable String accessId) {
@@ -35,13 +38,17 @@ public class UniversalIdentitySyncedAuthMethod extends SyncedAuthMethod {
 
     @Override
     public boolean isConfigured(@Nullable String accessId) {
-        return accessId != null && !accessId.isBlank()
-                && uidToken != null && !Secret.toString(uidToken).isBlank();
+        return accessId != null
+                && !accessId.isBlank()
+                && uidToken != null
+                && !Secret.toString(uidToken).isBlank();
     }
 
     @Extension
     public static class DescriptorImpl extends Descriptor<SyncedAuthMethod> {
         @Override
-        public String getDisplayName() { return "Universal Identity"; }
+        public String getDisplayName() {
+            return "Universal Identity";
+        }
     }
 }

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/client/AkeylessSyncedAuthResolver.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/client/AkeylessSyncedAuthResolver.java
@@ -1,0 +1,44 @@
+package io.jenkins.plugins.akeyless.synced.client;
+
+import hudson.model.User;
+import io.jenkins.plugins.akeyless.synced.config.AkeylessSyncedCredentialsProviderConfig;
+import io.jenkins.plugins.akeyless.synced.config.AkeylessSyncedUserAuthProperty;
+
+import javax.annotation.Nullable;
+
+/**
+ * Resolves an {@link AkeylessSyncedClient} from global or per-user authentication settings.
+ */
+public final class AkeylessSyncedAuthResolver {
+
+    private AkeylessSyncedAuthResolver() {}
+
+    /**
+     * @param ownerUserId Jenkins user id when credentials are user-scoped; {@code null} for global scope.
+     */
+    @Nullable
+    public static AkeylessSyncedClient resolveClient(@Nullable String ownerUserId) {
+        AkeylessSyncedCredentialsProviderConfig config = AkeylessSyncedCredentialsProviderConfig.get();
+        if (config == null || !config.hasAkeylessUrl()) {
+            return null;
+        }
+        String url = config.getAkeylessUrl().trim();
+
+        if (config.isPerUserAuthentication()) {
+            if (ownerUserId == null || ownerUserId.isBlank()) {
+                return null;
+            }
+            User user = User.getById(ownerUserId, false);
+            if (user == null) {
+                return null;
+            }
+            AkeylessSyncedUserAuthProperty auth = user.getProperty(AkeylessSyncedUserAuthProperty.class);
+            if (auth == null || !auth.isConfigured()) {
+                return null;
+            }
+            return auth.buildClient(url);
+        }
+
+        return config.buildClient();
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/client/AkeylessSyncedAuthResolver.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/client/AkeylessSyncedAuthResolver.java
@@ -3,7 +3,6 @@ package io.jenkins.plugins.akeyless.synced.client;
 import hudson.model.User;
 import io.jenkins.plugins.akeyless.synced.config.AkeylessSyncedCredentialsProviderConfig;
 import io.jenkins.plugins.akeyless.synced.config.AkeylessSyncedUserAuthProperty;
-
 import javax.annotation.Nullable;
 
 /**

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/client/AkeylessSyncedClient.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/client/AkeylessSyncedClient.java
@@ -16,10 +16,6 @@ import io.akeyless.client.model.Item;
 import io.akeyless.client.model.ListItems;
 import io.akeyless.client.model.ListItemsInPathOutput;
 import io.jenkins.plugins.akeyless.synced.auth.SyncedAuthMethod;
-import okhttp3.OkHttpClient;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -32,6 +28,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import okhttp3.OkHttpClient;
 
 public class AkeylessSyncedClient {
 
@@ -44,7 +43,8 @@ public class AkeylessSyncedClient {
     private V2Api api;
     private String token;
 
-    public AkeylessSyncedClient(@Nonnull String akeylessUrl, @Nullable String accessId, @Nonnull SyncedAuthMethod authMethod) {
+    public AkeylessSyncedClient(
+            @Nonnull String akeylessUrl, @Nullable String accessId, @Nonnull SyncedAuthMethod authMethod) {
         this.basePath = akeylessUrl.endsWith("/") ? akeylessUrl.substring(0, akeylessUrl.length() - 1) : akeylessUrl;
         this.accessId = accessId;
         this.authMethod = authMethod;
@@ -65,23 +65,29 @@ public class AkeylessSyncedClient {
             return token;
         }
         try {
-            LOG.log(Level.INFO, "Akeyless: authenticating with method={0}, access_id={1}",
-                    new Object[]{authMethod.getClass().getSimpleName(), accessId});
+            LOG.log(Level.INFO, "Akeyless: authenticating with method={0}, access_id={1}", new Object[] {
+                authMethod.getClass().getSimpleName(), accessId
+            });
             Auth auth = authMethod.buildAuth(accessId);
             AuthOutput authOutput = api().auth(auth);
             token = authOutput != null ? authOutput.getToken() : null;
             if (token == null || token.isEmpty()) {
                 throw new ApiException("Auth response had no token");
             }
-            LOG.log(Level.INFO, "Akeyless: authenticated successfully with {0}", authMethod.getClass().getSimpleName());
+            LOG.log(
+                    Level.INFO,
+                    "Akeyless: authenticated successfully with {0}",
+                    authMethod.getClass().getSimpleName());
             return token;
         } catch (ApiException e) {
-            LOG.log(Level.WARNING, "Akeyless: authentication failed with {0}: {1}",
-                    new Object[]{authMethod.getClass().getSimpleName(), e.getMessage()});
+            LOG.log(Level.WARNING, "Akeyless: authentication failed with {0}: {1}", new Object[] {
+                authMethod.getClass().getSimpleName(), e.getMessage()
+            });
             throw e;
         } catch (Exception e) {
-            LOG.log(Level.WARNING, "Akeyless: authentication failed with {0}: {1}",
-                    new Object[]{authMethod.getClass().getSimpleName(), e.getMessage()});
+            LOG.log(Level.WARNING, "Akeyless: authentication failed with {0}: {1}", new Object[] {
+                authMethod.getClass().getSimpleName(), e.getMessage()
+            });
             throw new ApiException("Authentication failed: " + e.getMessage());
         }
     }
@@ -240,8 +246,7 @@ public class AkeylessSyncedClient {
         }
         String certPem = out.getCertificatePem();
         String keyPem = out.getPrivateKeyPem();
-        if (certPem != null && keyPem != null
-                && !certPem.isBlank() && !keyPem.isBlank()) {
+        if (certPem != null && keyPem != null && !certPem.isBlank() && !keyPem.isBlank()) {
             return GetSecretValueResult.pemCertificate(certPem, keyPem);
         }
         if (certPem != null && !certPem.isBlank()) {
@@ -259,7 +264,8 @@ public class AkeylessSyncedClient {
     }
 
     @Nonnull
-    private static GetSecretValueResult mapOutputToResult(Map<String, Object> out, String pathForApi) throws ApiException {
+    private static GetSecretValueResult mapOutputToResult(Map<String, Object> out, String pathForApi)
+            throws ApiException {
         if (out == null || out.isEmpty()) {
             throw new ApiException("No value returned for secret: " + pathForApi);
         }
@@ -324,10 +330,13 @@ public class AkeylessSyncedClient {
             }
             return new HashMap<>(ItemTagParser.parseItemTags(item.getItemTags()));
         } catch (ApiException e) {
-            LOG.log(Level.WARNING, "Akeyless: describe-item failed for name={0}: {1}", new Object[]{name, e.getMessage()});
+            LOG.log(Level.WARNING, "Akeyless: describe-item failed for name={0}: {1}", new Object[] {
+                name, e.getMessage()
+            });
             return Collections.emptyMap();
         } catch (Exception e) {
-            LOG.log(Level.WARNING, "Akeyless: describe-item error for name={0}: {1}", new Object[]{name, e.getMessage()});
+            LOG.log(Level.WARNING, "Akeyless: describe-item error for name={0}: {1}", new Object[] {name, e.getMessage()
+            });
             return Collections.emptyMap();
         }
     }
@@ -350,7 +359,8 @@ public class AkeylessSyncedClient {
         private final String certificatePem;
         private final String privateKeyPem;
 
-        private GetSecretValueResult(String stringValue, byte[] binaryValue, String certificatePem, String privateKeyPem) {
+        private GetSecretValueResult(
+                String stringValue, byte[] binaryValue, String certificatePem, String privateKeyPem) {
             this.stringValue = stringValue;
             this.binaryValue = binaryValue;
             this.certificatePem = certificatePem;

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/client/AkeylessSyncedClient.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/client/AkeylessSyncedClient.java
@@ -1,0 +1,396 @@
+package io.jenkins.plugins.akeyless.synced.client;
+
+import com.google.gson.Gson;
+import io.akeyless.client.ApiClient;
+import io.akeyless.client.ApiException;
+import io.akeyless.client.api.V2Api;
+import io.akeyless.client.model.Auth;
+import io.akeyless.client.model.AuthOutput;
+import io.akeyless.client.model.DescribeItem;
+import io.akeyless.client.model.GetCertificateValue;
+import io.akeyless.client.model.GetCertificateValueOutput;
+import io.akeyless.client.model.GetDynamicSecretValue;
+import io.akeyless.client.model.GetRotatedSecretValue;
+import io.akeyless.client.model.GetSecretValue;
+import io.akeyless.client.model.Item;
+import io.akeyless.client.model.ListItems;
+import io.akeyless.client.model.ListItemsInPathOutput;
+import io.jenkins.plugins.akeyless.synced.auth.SyncedAuthMethod;
+import okhttp3.OkHttpClient;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class AkeylessSyncedClient {
+
+    private static final Logger LOG = Logger.getLogger(AkeylessSyncedClient.class.getName());
+    private static final Gson GSON = new Gson();
+
+    private final String basePath;
+    private final String accessId;
+    private final SyncedAuthMethod authMethod;
+    private V2Api api;
+    private String token;
+
+    public AkeylessSyncedClient(@Nonnull String akeylessUrl, @Nullable String accessId, @Nonnull SyncedAuthMethod authMethod) {
+        this.basePath = akeylessUrl.endsWith("/") ? akeylessUrl.substring(0, akeylessUrl.length() - 1) : akeylessUrl;
+        this.accessId = accessId;
+        this.authMethod = authMethod;
+    }
+
+    private synchronized V2Api api() {
+        if (api == null) {
+            OkHttpClient httpClient = JenkinsProxyOkHttp.newClient();
+            ApiClient client = new ApiClient(httpClient);
+            client.setBasePath(basePath);
+            api = new V2Api(client);
+        }
+        return api;
+    }
+
+    public synchronized String getToken() throws ApiException {
+        if (token != null && !token.isEmpty()) {
+            return token;
+        }
+        try {
+            LOG.log(Level.INFO, "Akeyless: authenticating with method={0}, access_id={1}",
+                    new Object[]{authMethod.getClass().getSimpleName(), accessId});
+            Auth auth = authMethod.buildAuth(accessId);
+            AuthOutput authOutput = api().auth(auth);
+            token = authOutput != null ? authOutput.getToken() : null;
+            if (token == null || token.isEmpty()) {
+                throw new ApiException("Auth response had no token");
+            }
+            LOG.log(Level.INFO, "Akeyless: authenticated successfully with {0}", authMethod.getClass().getSimpleName());
+            return token;
+        } catch (ApiException e) {
+            LOG.log(Level.WARNING, "Akeyless: authentication failed with {0}: {1}",
+                    new Object[]{authMethod.getClass().getSimpleName(), e.getMessage()});
+            throw e;
+        } catch (Exception e) {
+            LOG.log(Level.WARNING, "Akeyless: authentication failed with {0}: {1}",
+                    new Object[]{authMethod.getClass().getSimpleName(), e.getMessage()});
+            throw new ApiException("Authentication failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Resolves the secret value: {@code describe-item} first, then the fetch API that matches the item type
+     * (static, dynamic, rotated, certificate). Missing items surface as failure (typically HTTP 404 from describe).
+     */
+    @Nonnull
+    public GetSecretValueResult getSecretValue(String name) throws ApiException {
+        Item item = describeItemStrict(name);
+        String effectivePath = item.getItemName() != null && !item.getItemName().isBlank()
+                ? normalizeItemPath(item.getItemName())
+                : normalizeItemPath(name);
+        return fetchPayloadForItem(item, effectivePath);
+    }
+
+    /**
+     * Lists full item paths under a folder (recursive), using {@code list-items}. Used when only a folder path
+     * is configured so Jenkins can expose credential IDs without a manual name list.
+     */
+    @Nonnull
+    public List<String> listSecretItemPathsRecursive(@Nonnull String folderPath) throws ApiException {
+        String root = normalizeItemPath(folderPath);
+        List<String> paths = new ArrayList<>();
+        Set<String> visitedFolders = new HashSet<>();
+        Deque<String> folders = new ArrayDeque<>();
+        folders.add(root);
+        while (!folders.isEmpty()) {
+            String path = folders.removeFirst();
+            if (!visitedFolders.add(path)) {
+                continue;
+            }
+            String paginationToken = null;
+            while (true) {
+                ListItems body = new ListItems();
+                body.setToken(getToken());
+                body.setPath(path);
+                if (paginationToken != null && !paginationToken.isEmpty()) {
+                    body.setPaginationToken(paginationToken);
+                }
+                ListItemsInPathOutput page = api().listItems(body);
+                if (page.getItems() != null) {
+                    for (Item it : page.getItems()) {
+                        if (it.getItemName() != null && !it.getItemName().isBlank()) {
+                            paths.add(normalizeItemPath(it.getItemName()));
+                        }
+                    }
+                }
+                if (page.getFolders() != null) {
+                    for (String sub : page.getFolders()) {
+                        if (sub != null && !sub.isBlank()) {
+                            folders.addLast(normalizeItemPath(sub));
+                        }
+                    }
+                }
+                paginationToken = page.getNextPage();
+                if (!Boolean.TRUE.equals(page.getHasNext()) || paginationToken == null || paginationToken.isEmpty()) {
+                    break;
+                }
+            }
+        }
+        return paths;
+    }
+
+    @Nonnull
+    private Item describeItemStrict(String name) throws ApiException {
+        String n = normalizeItemPath(name);
+        DescribeItem body = new DescribeItem();
+        body.setToken(getToken());
+        body.setName(n);
+        try {
+            Item item = api().describeItem(body);
+            if (item == null) {
+                throw new ApiException(404, "Item not found: " + n);
+            }
+            return item;
+        } catch (ApiException e) {
+            if (isNotFound(e)) {
+                throw new ApiException(404, "Secret not found (404): " + n);
+            }
+            throw e;
+        }
+    }
+
+    private static boolean isNotFound(ApiException e) {
+        if (e.getCode() == 404) {
+            return true;
+        }
+        String msg = e.getMessage();
+        return msg != null && msg.toLowerCase(Locale.ROOT).contains("not found");
+    }
+
+    @Nonnull
+    private GetSecretValueResult fetchPayloadForItem(Item item, String effectivePathAkeyless) throws ApiException {
+        String itemType = safeLower(item.getItemType());
+        String itemSubType = safeLower(item.getItemSubType());
+
+        if (itemType.contains("dynamic")) {
+            return fetchDynamic(effectivePathAkeyless);
+        }
+        if (itemType.contains("rotated")) {
+            return fetchRotated(effectivePathAkeyless);
+        }
+        if (itemType.contains("certificate") || itemSubType.contains("certificate")) {
+            return fetchCertificate(effectivePathAkeyless);
+        }
+        return fetchStaticSecret(effectivePathAkeyless);
+    }
+
+    private static String safeLower(@Nullable String s) {
+        return s == null ? "" : s.toLowerCase(Locale.ROOT);
+    }
+
+    @Nonnull
+    private GetSecretValueResult fetchStaticSecret(String pathForApi) throws ApiException {
+        LOG.log(Level.INFO, "Akeyless: get-secret-value for path={0}", pathForApi);
+        GetSecretValue body = new GetSecretValue();
+        body.setToken(getToken());
+        body.setNames(Collections.singletonList(pathForApi));
+        Map<String, Object> out = api().getSecretValue(body);
+        return mapOutputToResult(out, pathForApi);
+    }
+
+    @Nonnull
+    private GetSecretValueResult fetchDynamic(String effectivePath) throws ApiException {
+        LOG.log(Level.INFO, "Akeyless: get-dynamic-secret-value for name={0}", effectivePath);
+        GetDynamicSecretValue body = new GetDynamicSecretValue();
+        body.setToken(getToken());
+        body.setName(trimLeadingSlash(effectivePath));
+        body.setJson(true);
+        Map<String, Object> out = api().getDynamicSecretValue(body);
+        return mapToJsonResult(out);
+    }
+
+    @Nonnull
+    private GetSecretValueResult fetchRotated(String effectivePath) throws ApiException {
+        LOG.log(Level.INFO, "Akeyless: get-rotated-secret-value for names={0}", effectivePath);
+        GetRotatedSecretValue body = new GetRotatedSecretValue();
+        body.setToken(getToken());
+        body.setNames(trimLeadingSlash(effectivePath));
+        body.setJson(true);
+        Map<String, Object> out = api().getRotatedSecretValue(body);
+        return mapToJsonResult(out);
+    }
+
+    @Nonnull
+    private GetSecretValueResult fetchCertificate(String effectivePath) throws ApiException {
+        LOG.log(Level.INFO, "Akeyless: get-certificate-value for name={0}", effectivePath);
+        GetCertificateValue body = new GetCertificateValue();
+        body.setToken(getToken());
+        body.setName(trimLeadingSlash(effectivePath));
+        GetCertificateValueOutput out = api().getCertificateValue(body);
+        if (out == null) {
+            throw new ApiException("No certificate payload returned for: " + effectivePath);
+        }
+        String certPem = out.getCertificatePem();
+        String keyPem = out.getPrivateKeyPem();
+        if (certPem != null && keyPem != null
+                && !certPem.isBlank() && !keyPem.isBlank()) {
+            return GetSecretValueResult.pemCertificate(certPem, keyPem);
+        }
+        if (certPem != null && !certPem.isBlank()) {
+            return GetSecretValueResult.string(certPem);
+        }
+        throw new ApiException("Certificate response had no PEM data for: " + effectivePath);
+    }
+
+    @Nonnull
+    private static GetSecretValueResult mapToJsonResult(Map<String, Object> out) throws ApiException {
+        if (out == null || out.isEmpty()) {
+            throw new ApiException("Empty value from Akeyless");
+        }
+        return GetSecretValueResult.string(GSON.toJson(out));
+    }
+
+    @Nonnull
+    private static GetSecretValueResult mapOutputToResult(Map<String, Object> out, String pathForApi) throws ApiException {
+        if (out == null || out.isEmpty()) {
+            throw new ApiException("No value returned for secret: " + pathForApi);
+        }
+        Object value = out.get(pathForApi);
+        if (value == null && out.size() == 1) {
+            value = out.values().iterator().next();
+        }
+        if (value == null) {
+            throw new ApiException("Empty value for secret: " + pathForApi);
+        }
+        if (value instanceof String) {
+            return GetSecretValueResult.string((String) value);
+        }
+        if (value instanceof byte[]) {
+            return GetSecretValueResult.binary((byte[]) value);
+        }
+        if (value instanceof Map) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> m = (Map<String, Object>) value;
+            if (m.containsKey("value")) {
+                Object v = m.get("value");
+                if (v instanceof String) {
+                    return GetSecretValueResult.string((String) v);
+                }
+                if (v instanceof byte[]) {
+                    return GetSecretValueResult.binary((byte[]) v);
+                }
+            }
+            return GetSecretValueResult.string(m.toString());
+        }
+        return GetSecretValueResult.string(value.toString());
+    }
+
+    private static String trimLeadingSlash(String path) {
+        if (path == null || path.isEmpty()) {
+            return path;
+        }
+        return path.startsWith("/") ? path.substring(1) : path;
+    }
+
+    /**
+     * Reads item tags from Akeyless via {@code describe-item} (same keys as AWS Secrets Manager plugin:
+     * {@code jenkins:credentials:type}, {@code jenkins:credentials:username}, etc.).
+     * On failure returns an empty map so callers can fall back to defaults.
+     */
+    @Nonnull
+    public Map<String, String> getItemTags(@Nonnull String itemPath) {
+        String name = itemPath == null ? "" : itemPath.trim();
+        if (name.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        if (!name.startsWith("/")) {
+            name = "/" + name;
+        }
+        try {
+            DescribeItem body = new DescribeItem();
+            body.setToken(getToken());
+            body.setName(name);
+            Item item = api().describeItem(body);
+            if (item == null || item.getItemTags() == null) {
+                return Collections.emptyMap();
+            }
+            return new HashMap<>(ItemTagParser.parseItemTags(item.getItemTags()));
+        } catch (ApiException e) {
+            LOG.log(Level.WARNING, "Akeyless: describe-item failed for name={0}: {1}", new Object[]{name, e.getMessage()});
+            return Collections.emptyMap();
+        } catch (Exception e) {
+            LOG.log(Level.WARNING, "Akeyless: describe-item error for name={0}: {1}", new Object[]{name, e.getMessage()});
+            return Collections.emptyMap();
+        }
+    }
+
+    /** Normalizes to a path with a leading {@code /} for Akeyless APIs. */
+    public static String normalizeItemPath(String name) {
+        String pathForApi = name == null ? "" : name.trim();
+        if (pathForApi.isEmpty()) {
+            return pathForApi;
+        }
+        if (!pathForApi.startsWith("/")) {
+            pathForApi = "/" + pathForApi;
+        }
+        return pathForApi;
+    }
+
+    public static final class GetSecretValueResult {
+        private final String stringValue;
+        private final byte[] binaryValue;
+        private final String certificatePem;
+        private final String privateKeyPem;
+
+        private GetSecretValueResult(String stringValue, byte[] binaryValue, String certificatePem, String privateKeyPem) {
+            this.stringValue = stringValue;
+            this.binaryValue = binaryValue;
+            this.certificatePem = certificatePem;
+            this.privateKeyPem = privateKeyPem;
+        }
+
+        public static GetSecretValueResult string(String s) {
+            return new GetSecretValueResult(s, null, null, null);
+        }
+
+        public static GetSecretValueResult binary(byte[] b) {
+            return new GetSecretValueResult(null, b, null, null);
+        }
+
+        public static GetSecretValueResult pemCertificate(String certificatePem, String privateKeyPem) {
+            return new GetSecretValueResult(null, null, certificatePem, privateKeyPem);
+        }
+
+        public boolean isString() {
+            return stringValue != null;
+        }
+
+        public boolean isPemCertificatePair() {
+            return certificatePem != null && privateKeyPem != null;
+        }
+
+        public String getStringValue() {
+            return stringValue;
+        }
+
+        public byte[] getBinaryValue() {
+            return binaryValue;
+        }
+
+        public String getCertificatePem() {
+            return certificatePem;
+        }
+
+        public String getPrivateKeyPem() {
+            return privateKeyPem;
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/client/ItemTagParser.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/client/ItemTagParser.java
@@ -1,0 +1,57 @@
+package io.jenkins.plugins.akeyless.synced.client;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Parses Akeyless {@link io.akeyless.client.model.Item#getItemTags()} entries into a flat key → value map.
+ * Supports common formats: {@code key=value}, {@code key:value}, or JSON objects with {@code key}/{@code value} fields.
+ */
+final class ItemTagParser {
+
+    private ItemTagParser() {}
+
+    static Map<String, String> parseItemTags(List<String> itemTags) {
+        if (itemTags == null || itemTags.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<String, String> out = new HashMap<>();
+        for (String raw : itemTags) {
+            if (raw == null || raw.isBlank()) {
+                continue;
+            }
+            String s = raw.trim();
+            if (s.startsWith("{")) {
+                parseJsonTagEntry(s, out);
+                continue;
+            }
+            int eq = s.indexOf('=');
+            if (eq > 0) {
+                out.put(s.substring(0, eq).trim(), s.substring(eq + 1).trim());
+                continue;
+            }
+            int col = s.indexOf(':');
+            if (col > 0) {
+                out.put(s.substring(0, col).trim(), s.substring(col + 1).trim());
+            }
+        }
+        return out;
+    }
+
+    private static void parseJsonTagEntry(String s, Map<String, String> out) {
+        try {
+            com.google.gson.JsonElement el = com.google.gson.JsonParser.parseString(s);
+            if (!el.isJsonObject()) {
+                return;
+            }
+            com.google.gson.JsonObject o = el.getAsJsonObject();
+            if (o.has("key") && o.has("value") && o.get("key").isJsonPrimitive() && o.get("value").isJsonPrimitive()) {
+                out.put(o.get("key").getAsString(), o.get("value").getAsString());
+            }
+        } catch (RuntimeException ignored) {
+            // ignore malformed JSON tag lines
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/client/ItemTagParser.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/client/ItemTagParser.java
@@ -47,7 +47,10 @@ final class ItemTagParser {
                 return;
             }
             com.google.gson.JsonObject o = el.getAsJsonObject();
-            if (o.has("key") && o.has("value") && o.get("key").isJsonPrimitive() && o.get("value").isJsonPrimitive()) {
+            if (o.has("key")
+                    && o.has("value")
+                    && o.get("key").isJsonPrimitive()
+                    && o.get("value").isJsonPrimitive()) {
                 out.put(o.get("key").getAsString(), o.get("value").getAsString());
             }
         } catch (RuntimeException ignored) {

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/client/JenkinsProxyOkHttp.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/client/JenkinsProxyOkHttp.java
@@ -1,0 +1,111 @@
+package io.jenkins.plugins.akeyless.synced.client;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.ProxyConfiguration;
+import hudson.util.Secret;
+import jenkins.model.Jenkins;
+import okhttp3.Authenticator;
+import okhttp3.Credentials;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.Route;
+
+import java.io.IOException;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Applies Jenkins {@link ProxyConfiguration} (Manage Jenkins → System → HTTP Proxy Configuration)
+ * to an {@link OkHttpClient.Builder} used by the Akeyless Java SDK.
+ */
+public final class JenkinsProxyOkHttp {
+
+    private static final Logger LOG = Logger.getLogger(JenkinsProxyOkHttp.class.getName());
+
+    private JenkinsProxyOkHttp() {}
+
+    /**
+     * Returns a new {@link OkHttpClient} with Jenkins proxy settings applied when configured.
+     */
+    @NonNull
+    public static OkHttpClient newClient() {
+        return configure(new OkHttpClient.Builder()).build();
+    }
+
+    /**
+     * Applies Jenkins proxy host/port, no-proxy hosts, and proxy authentication to the builder.
+     */
+    @NonNull
+    public static OkHttpClient.Builder configure(@NonNull OkHttpClient.Builder builder) {
+        ProxyConfiguration proxy = currentProxy();
+        if (proxy == null || proxy.getName() == null || proxy.getName().isBlank()) {
+            return builder;
+        }
+        LOG.log(Level.FINE, "Akeyless Credentials Provider: using Jenkins HTTP proxy {0}:{1}",
+                new Object[]{proxy.getName(), proxy.getPort()});
+        builder.proxySelector(new JenkinsProxySelector());
+        builder.proxyAuthenticator(new JenkinsProxyAuthenticator());
+        return builder;
+    }
+
+    @Nullable
+    private static ProxyConfiguration currentProxy() {
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        return jenkins == null ? null : jenkins.getProxy();
+    }
+
+    private static final class JenkinsProxySelector extends ProxySelector {
+
+        @Override
+        public List<Proxy> select(URI uri) {
+            ProxyConfiguration configuration = currentProxy();
+            if (configuration == null) {
+                return Collections.singletonList(Proxy.NO_PROXY);
+            }
+            return List.of(configuration.createProxy(uri.getHost()));
+        }
+
+        @Override
+        public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
+            LOG.log(Level.FINE, "Akeyless Credentials Provider: proxy connection failed for {0}", uri);
+        }
+    }
+
+    private static final class JenkinsProxyAuthenticator implements Authenticator {
+
+        @Nullable
+        @Override
+        public Request authenticate(@Nullable Route route, Response response) throws IOException {
+            ProxyConfiguration proxy = currentProxy();
+            if (proxy == null || proxy.getUserName() == null) {
+                return null;
+            }
+            if (response.request().header("Proxy-Authorization") != null) {
+                return null;
+            }
+            String proxyAuthenticateHeader = response.header("Proxy-Authenticate");
+            if (proxyAuthenticateHeader == null) {
+                return null;
+            }
+            if (!proxyAuthenticateHeader.toLowerCase(Locale.ROOT).startsWith("basic")) {
+                LOG.log(Level.WARNING,
+                        "Akeyless Credentials Provider: unsupported proxy authentication scheme: {0}",
+                        proxyAuthenticateHeader);
+                return null;
+            }
+            String credential = Credentials.basic(proxy.getUserName(), Secret.toString(proxy.getSecretPassword()));
+            return response.request().newBuilder()
+                    .header("Proxy-Authorization", credential)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/client/JenkinsProxyOkHttp.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/client/JenkinsProxyOkHttp.java
@@ -4,14 +4,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.ProxyConfiguration;
 import hudson.util.Secret;
-import jenkins.model.Jenkins;
-import okhttp3.Authenticator;
-import okhttp3.Credentials;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
-import okhttp3.Route;
-
 import java.io.IOException;
 import java.net.Proxy;
 import java.net.ProxySelector;
@@ -22,6 +14,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.model.Jenkins;
+import okhttp3.Authenticator;
+import okhttp3.Credentials;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.Route;
 
 /**
  * Applies Jenkins {@link ProxyConfiguration} (Manage Jenkins → System → HTTP Proxy Configuration)
@@ -50,8 +49,9 @@ public final class JenkinsProxyOkHttp {
         if (proxy == null || proxy.getName() == null || proxy.getName().isBlank()) {
             return builder;
         }
-        LOG.log(Level.FINE, "Akeyless Credentials Provider: using Jenkins HTTP proxy {0}:{1}",
-                new Object[]{proxy.getName(), proxy.getPort()});
+        LOG.log(Level.FINE, "Akeyless Credentials Provider: using Jenkins HTTP proxy {0}:{1}", new Object[] {
+            proxy.getName(), proxy.getPort()
+        });
         builder.proxySelector(new JenkinsProxySelector());
         builder.proxyAuthenticator(new JenkinsProxyAuthenticator());
         return builder;
@@ -84,7 +84,11 @@ public final class JenkinsProxyOkHttp {
 
         @Nullable
         @Override
-        public Request authenticate(@Nullable Route route, Response response) throws IOException {
+        @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+                value = "NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION",
+                justification =
+                        "OkHttp Authenticator.authenticate marks Route as org.jetbrains.annotations.Nullable; SpotBugs does not treat that as matching edu.umd.cs.findbugs.annotations.Nullable")
+        public Request authenticate(@Nullable Route route, @NonNull Response response) throws IOException {
             ProxyConfiguration proxy = currentProxy();
             if (proxy == null || proxy.getUserName() == null) {
                 return null;
@@ -97,13 +101,15 @@ public final class JenkinsProxyOkHttp {
                 return null;
             }
             if (!proxyAuthenticateHeader.toLowerCase(Locale.ROOT).startsWith("basic")) {
-                LOG.log(Level.WARNING,
+                LOG.log(
+                        Level.WARNING,
                         "Akeyless Credentials Provider: unsupported proxy authentication scheme: {0}",
                         proxyAuthenticateHeader);
                 return null;
             }
             String credential = Credentials.basic(proxy.getUserName(), Secret.toString(proxy.getSecretPassword()));
-            return response.request().newBuilder()
+            return response.request()
+                    .newBuilder()
                     .header("Proxy-Authorization", credential)
                     .build();
         }

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/client/PemPkcs12Util.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/client/PemPkcs12Util.java
@@ -14,7 +14,6 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Base64;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import javax.annotation.Nonnull;
 
 /**
@@ -23,21 +22,20 @@ import javax.annotation.Nonnull;
  */
 public final class PemPkcs12Util {
 
-    private static final Pattern PEM_BLOCK = Pattern.compile(
-            "-----BEGIN ([^-]+)-----\\s*([\\s\\S]*?)-----END \\1-----", Pattern.MULTILINE);
+    private static final Pattern PEM_BLOCK =
+            Pattern.compile("-----BEGIN ([^-]+)-----\\s*([\\s\\S]*?)-----END \\1-----", Pattern.MULTILINE);
 
     private PemPkcs12Util() {}
 
     @Nonnull
     public static java.security.KeyStore buildPkcs12KeyStore(
-            @Nonnull String certificatePem,
-            @Nonnull String privateKeyPem,
-            char[] password) throws GeneralSecurityException, IOException {
+            @Nonnull String certificatePem, @Nonnull String privateKeyPem, char[] password)
+            throws GeneralSecurityException, IOException {
         X509Certificate cert = parseCertificate(certificatePem);
         PrivateKey privateKey = parsePrivateKey(privateKeyPem);
         java.security.KeyStore ks = java.security.KeyStore.getInstance("PKCS12");
         ks.load(null, password);
-        ks.setKeyEntry("akeyless", privateKey, password, new Certificate[]{cert});
+        ks.setKeyEntry("akeyless", privateKey, password, new Certificate[] {cert});
         return ks;
     }
 

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/client/PemPkcs12Util.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/client/PemPkcs12Util.java
@@ -1,0 +1,79 @@
+package io.jenkins.plugins.akeyless.synced.client;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Builds a PKCS#12 {@link java.security.KeyStore} from PEM certificate and private key returned by
+ * {@code get-certificate-value}.
+ */
+public final class PemPkcs12Util {
+
+    private static final Pattern PEM_BLOCK = Pattern.compile(
+            "-----BEGIN ([^-]+)-----\\s*([\\s\\S]*?)-----END \\1-----", Pattern.MULTILINE);
+
+    private PemPkcs12Util() {}
+
+    @Nonnull
+    public static java.security.KeyStore buildPkcs12KeyStore(
+            @Nonnull String certificatePem,
+            @Nonnull String privateKeyPem,
+            char[] password) throws GeneralSecurityException, IOException {
+        X509Certificate cert = parseCertificate(certificatePem);
+        PrivateKey privateKey = parsePrivateKey(privateKeyPem);
+        java.security.KeyStore ks = java.security.KeyStore.getInstance("PKCS12");
+        ks.load(null, password);
+        ks.setKeyEntry("akeyless", privateKey, password, new Certificate[]{cert});
+        return ks;
+    }
+
+    private static X509Certificate parseCertificate(String pem) throws CertificateException {
+        byte[] der = decodeFirstPemBlock(pem, "CERTIFICATE");
+        if (der == null) {
+            throw new CertificateException("No PEM CERTIFICATE block found");
+        }
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        return (X509Certificate) cf.generateCertificate(new ByteArrayInputStream(der));
+    }
+
+    private static PrivateKey parsePrivateKey(String pem) throws GeneralSecurityException {
+        byte[] der = decodeFirstPemBlock(pem, "PRIVATE KEY");
+        if (der == null) {
+            der = decodeFirstPemBlock(pem, "EC PRIVATE KEY");
+        }
+        if (der == null) {
+            throw new InvalidKeySpecException("No PEM private key block found");
+        }
+        PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(der);
+        try {
+            return KeyFactory.getInstance("RSA").generatePrivate(spec);
+        } catch (InvalidKeySpecException e) {
+            return KeyFactory.getInstance("EC").generatePrivate(spec);
+        }
+    }
+
+    private static byte[] decodeFirstPemBlock(String pem, String kind) {
+        Matcher m = PEM_BLOCK.matcher(pem);
+        while (m.find()) {
+            if (kind.equals(m.group(1).trim())) {
+                String b64 = m.group(2).replaceAll("\\s", "");
+                return Base64.getDecoder().decode(b64);
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/config/AkeylessSyncedCredentialsProviderConfig.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/config/AkeylessSyncedCredentialsProviderConfig.java
@@ -10,15 +10,14 @@ import io.jenkins.plugins.akeyless.synced.config.scope.AuthenticationScopeMode;
 import io.jenkins.plugins.akeyless.synced.config.scope.GlobalAuthenticationScopeMode;
 import io.jenkins.plugins.akeyless.synced.config.scope.PerUserAuthenticationScopeMode;
 import io.jenkins.plugins.akeyless.synced.supplier.FolderListingCache;
+import java.util.List;
+import javax.annotation.Nullable;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.interceptor.RequirePOST;
-
-import javax.annotation.Nullable;
-import java.util.List;
 
 @Extension
 public class AkeylessSyncedCredentialsProviderConfig extends jenkins.model.GlobalConfiguration {
@@ -39,6 +38,7 @@ public class AkeylessSyncedCredentialsProviderConfig extends jenkins.model.Globa
     /** @deprecated legacy string/enum from older releases; migrated in {@link #getAuthenticationScopeMode()}. */
     @Deprecated
     private String authenticationScope;
+
     private String accessId;
     private SyncedAuthMethod authMethod;
     /** Folder path: secrets are at folderPath + "/" + secretName. No listing. */
@@ -58,10 +58,14 @@ public class AkeylessSyncedCredentialsProviderConfig extends jenkins.model.Globa
      */
     private Boolean cache;
 
-    public String getAkeylessUrl() { return akeylessUrl; }
+    public String getAkeylessUrl() {
+        return akeylessUrl;
+    }
 
     @DataBoundSetter
-    public void setAkeylessUrl(String akeylessUrl) { this.akeylessUrl = akeylessUrl; }
+    public void setAkeylessUrl(String akeylessUrl) {
+        this.akeylessUrl = akeylessUrl;
+    }
 
     public AuthenticationScopeMode getAuthenticationScopeMode() {
         if (authenticationScopeMode != null) {
@@ -89,15 +93,23 @@ public class AkeylessSyncedCredentialsProviderConfig extends jenkins.model.Globa
         return akeylessUrl != null && !akeylessUrl.isBlank();
     }
 
-    public String getAccessId() { return accessId; }
+    public String getAccessId() {
+        return accessId;
+    }
 
     @DataBoundSetter
-    public void setAccessId(String accessId) { this.accessId = accessId; }
+    public void setAccessId(String accessId) {
+        this.accessId = accessId;
+    }
 
-    public SyncedAuthMethod getAuthMethod() { return authMethod; }
+    public SyncedAuthMethod getAuthMethod() {
+        return authMethod;
+    }
 
     @DataBoundSetter
-    public void setAuthMethod(SyncedAuthMethod authMethod) { this.authMethod = authMethod; }
+    public void setAuthMethod(SyncedAuthMethod authMethod) {
+        this.authMethod = authMethod;
+    }
 
     /** Folder path; when not set, pathPrefix is used (so old config works as folder path). */
     public String getFolderPath() {
@@ -107,12 +119,18 @@ public class AkeylessSyncedCredentialsProviderConfig extends jenkins.model.Globa
     }
 
     @DataBoundSetter
-    public void setFolderPath(String folderPath) { this.folderPath = folderPath; }
+    public void setFolderPath(String folderPath) {
+        this.folderPath = folderPath;
+    }
 
-    public String getSecretNames() { return secretNames; }
+    public String getSecretNames() {
+        return secretNames;
+    }
 
     @DataBoundSetter
-    public void setSecretNames(String secretNames) { this.secretNames = secretNames; }
+    public void setSecretNames(String secretNames) {
+        this.secretNames = secretNames;
+    }
 
     /** Full secret paths only (one per line). pathPrefix is not used here — it is used as folder path when Folder path is empty. */
     public String getSecretPaths() {
@@ -120,13 +138,19 @@ public class AkeylessSyncedCredentialsProviderConfig extends jenkins.model.Globa
     }
 
     @DataBoundSetter
-    public void setSecretPaths(String secretPaths) { this.secretPaths = secretPaths; }
+    public void setSecretPaths(String secretPaths) {
+        this.secretPaths = secretPaths;
+    }
 
     /** @deprecated use folderPath or secretPaths */
-    public String getPathPrefix() { return pathPrefix; }
+    public String getPathPrefix() {
+        return pathPrefix;
+    }
 
     @DataBoundSetter
-    public void setPathPrefix(String pathPrefix) { this.pathPrefix = pathPrefix; }
+    public void setPathPrefix(String pathPrefix) {
+        this.pathPrefix = pathPrefix;
+    }
 
     public Boolean getCache() {
         return cache;
@@ -144,8 +168,7 @@ public class AkeylessSyncedCredentialsProviderConfig extends jenkins.model.Globa
 
     @RequirePOST
     @SuppressWarnings("unused")
-    public FormValidation doCheckFolderPath(@QueryParameter String folderPath,
-                                            @QueryParameter String pathPrefix) {
+    public FormValidation doCheckFolderPath(@QueryParameter String folderPath, @QueryParameter String pathPrefix) {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         String fp = folderPath;
         if (fp == null || fp.isBlank()) {

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/config/AkeylessSyncedCredentialsProviderConfig.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/config/AkeylessSyncedCredentialsProviderConfig.java
@@ -1,0 +1,234 @@
+package io.jenkins.plugins.akeyless.synced.config;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.model.Descriptor.FormException;
+import hudson.util.FormValidation;
+import io.jenkins.plugins.akeyless.synced.auth.SyncedAuthMethod;
+import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient;
+import io.jenkins.plugins.akeyless.synced.config.scope.AuthenticationScopeMode;
+import io.jenkins.plugins.akeyless.synced.config.scope.GlobalAuthenticationScopeMode;
+import io.jenkins.plugins.akeyless.synced.config.scope.PerUserAuthenticationScopeMode;
+import io.jenkins.plugins.akeyless.synced.supplier.FolderListingCache;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.interceptor.RequirePOST;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+@Extension
+public class AkeylessSyncedCredentialsProviderConfig extends jenkins.model.GlobalConfiguration {
+
+    public static AkeylessSyncedCredentialsProviderConfig get() {
+        return jenkins.model.GlobalConfiguration.all().get(AkeylessSyncedCredentialsProviderConfig.class);
+    }
+
+    public AkeylessSyncedCredentialsProviderConfig() {
+        load();
+    }
+
+    private String akeylessUrl;
+    /**
+     * Selected scope (same UI control as Authentication Method: {@code f:dropdownDescriptorSelector}).
+     */
+    private AuthenticationScopeMode authenticationScopeMode;
+    /** @deprecated legacy string/enum from older releases; migrated in {@link #getAuthenticationScopeMode()}. */
+    @Deprecated
+    private String authenticationScope;
+    private String accessId;
+    private SyncedAuthMethod authMethod;
+    /** Folder path: secrets are at folderPath + "/" + secretName. No listing. */
+    private String folderPath;
+    /** Secret names under the folder (one per line). In the job use credentials('secretName'). */
+    private String secretNames;
+    /** Full secret paths (one per line). Alternative to folder + names; no listing. */
+    private String secretPaths;
+    /** @deprecated use folderPath or secretPaths; kept for backward compatibility */
+    private String pathPrefix;
+
+    /**
+     * When true (default), recursive {@code list-items} results for folder-only discovery are cached
+     * ({@link io.jenkins.plugins.akeyless.synced.supplier.FolderListingCache#DEFAULT_CACHE_TTL_SECONDS}
+     * seconds, aligned with the AWS provider five-minute cache behavior). When false, each credentials refresh
+     * triggers a fresh {@code list-items}.
+     */
+    private Boolean cache;
+
+    public String getAkeylessUrl() { return akeylessUrl; }
+
+    @DataBoundSetter
+    public void setAkeylessUrl(String akeylessUrl) { this.akeylessUrl = akeylessUrl; }
+
+    public AuthenticationScopeMode getAuthenticationScopeMode() {
+        if (authenticationScopeMode != null) {
+            return authenticationScopeMode;
+        }
+        if (authenticationScope != null && !authenticationScope.isBlank()) {
+            return AuthenticationScope.fromString(authenticationScope).isPerUser()
+                    ? new PerUserAuthenticationScopeMode()
+                    : new GlobalAuthenticationScopeMode();
+        }
+        return new GlobalAuthenticationScopeMode();
+    }
+
+    @DataBoundSetter
+    public void setAuthenticationScopeMode(AuthenticationScopeMode authenticationScopeMode) {
+        this.authenticationScopeMode = authenticationScopeMode;
+        this.authenticationScope = null;
+    }
+
+    public boolean isPerUserAuthentication() {
+        return getAuthenticationScopeMode().isPerUser();
+    }
+
+    public boolean hasAkeylessUrl() {
+        return akeylessUrl != null && !akeylessUrl.isBlank();
+    }
+
+    public String getAccessId() { return accessId; }
+
+    @DataBoundSetter
+    public void setAccessId(String accessId) { this.accessId = accessId; }
+
+    public SyncedAuthMethod getAuthMethod() { return authMethod; }
+
+    @DataBoundSetter
+    public void setAuthMethod(SyncedAuthMethod authMethod) { this.authMethod = authMethod; }
+
+    /** Folder path; when not set, pathPrefix is used (so old config works as folder path). */
+    public String getFolderPath() {
+        if (folderPath != null && !folderPath.isBlank()) return folderPath;
+        if (pathPrefix != null && !pathPrefix.isBlank()) return pathPrefix;
+        return folderPath;
+    }
+
+    @DataBoundSetter
+    public void setFolderPath(String folderPath) { this.folderPath = folderPath; }
+
+    public String getSecretNames() { return secretNames; }
+
+    @DataBoundSetter
+    public void setSecretNames(String secretNames) { this.secretNames = secretNames; }
+
+    /** Full secret paths only (one per line). pathPrefix is not used here — it is used as folder path when Folder path is empty. */
+    public String getSecretPaths() {
+        return secretPaths;
+    }
+
+    @DataBoundSetter
+    public void setSecretPaths(String secretPaths) { this.secretPaths = secretPaths; }
+
+    /** @deprecated use folderPath or secretPaths */
+    public String getPathPrefix() { return pathPrefix; }
+
+    @DataBoundSetter
+    public void setPathPrefix(String pathPrefix) { this.pathPrefix = pathPrefix; }
+
+    public Boolean getCache() {
+        return cache;
+    }
+
+    @DataBoundSetter
+    public void setCache(Boolean cache) {
+        this.cache = cache;
+    }
+
+    /** @return whether list-items discovery should use the in-memory cache (default {@code true}). */
+    public boolean isCache() {
+        return cache == null || cache;
+    }
+
+    @RequirePOST
+    @SuppressWarnings("unused")
+    public FormValidation doCheckFolderPath(@QueryParameter String folderPath,
+                                            @QueryParameter String pathPrefix) {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        String fp = folderPath;
+        if (fp == null || fp.isBlank()) {
+            fp = pathPrefix;
+        }
+        if (FolderPathRules.isForbiddenRootFolder(fp)) {
+            return FormValidation.error(
+                    "Folder path cannot be '/' or '//' alone — that would list the entire vault. Use a concrete path "
+                            + "(e.g. /CICD/jenkins/secrets).");
+        }
+        return FormValidation.ok();
+    }
+
+    /** True when URL and global auth are set (global authentication scope only). */
+    public boolean isConfigured() {
+        return hasAkeylessUrl()
+                && !isPerUserAuthentication()
+                && authMethod != null
+                && authMethod.isConfigured(accessId);
+    }
+
+    /** True when URL is set and secret discovery inputs are present (auth may be per-user). */
+    public boolean isDiscoveryConfigured() {
+        if (!hasAkeylessUrl()) {
+            return false;
+        }
+        String folderPathEff = getFolderPath();
+        if (folderPathEff == null) {
+            folderPathEff = "";
+        }
+        boolean hasNames = secretNames != null && !secretNames.isBlank();
+        boolean hasPaths = secretPaths != null && !secretPaths.isBlank();
+        boolean hasFolderAndNames = !folderPathEff.isBlank() && hasNames;
+        boolean hasFolderOnly = !folderPathEff.isBlank() && !hasFolderAndNames && !hasPaths;
+        return hasFolderAndNames || hasPaths || hasFolderOnly;
+    }
+
+    @Nullable
+    public AkeylessSyncedClient buildClient() {
+        if (!hasAkeylessUrl() || isPerUserAuthentication()) {
+            return null;
+        }
+        if (authMethod == null || !authMethod.isConfigured(accessId)) {
+            return null;
+        }
+        String url = akeylessUrl.trim();
+        return new AkeylessSyncedClient(url, accessId != null ? accessId.trim() : null, authMethod);
+    }
+
+    public List<Descriptor<SyncedAuthMethod>> getAuthMethodDescriptors() {
+        return SyncedAuthMethod.all().stream()
+                .map(d -> (Descriptor<SyncedAuthMethod>) d)
+                .toList();
+    }
+
+    public List<Descriptor<AuthenticationScopeMode>> getAuthenticationScopeDescriptors() {
+        return AuthenticationScopeMode.all();
+    }
+
+    @Override
+    public boolean configure(StaplerRequest2 req, JSONObject json) throws FormException {
+        JSONObject section = json.optJSONObject("akeyless-synced-credentials-provider");
+        if (section == null) {
+            // Backward-compatible section name from standalone credentials-provider builds
+            section = json.optJSONObject("akeyless-credentials-provider");
+        }
+        req.bindJSON(this, section != null ? section : json);
+        String folderPathEff = getFolderPath();
+        if (folderPathEff == null) {
+            folderPathEff = "";
+        }
+        boolean hasNames = secretNames != null && !secretNames.isBlank();
+        boolean hasPaths = secretPaths != null && !secretPaths.isBlank();
+        boolean hasFolderAndNames = !folderPathEff.isBlank() && hasNames;
+        boolean hasFolderOnly = !folderPathEff.isBlank() && !hasFolderAndNames && !hasPaths;
+        if ((hasFolderOnly || hasFolderAndNames) && FolderPathRules.isForbiddenRootFolder(folderPathEff)) {
+            throw new FormException(
+                    "Folder path cannot be '/' or '//' alone — that would list the entire vault. "
+                            + "Use a concrete folder (e.g. /CICD/jenkins/secrets), or use Secret paths only.",
+                    "folderPath");
+        }
+        FolderListingCache.invalidate();
+        save();
+        return true;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/config/AkeylessSyncedUserAuthProperty.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/config/AkeylessSyncedUserAuthProperty.java
@@ -7,11 +7,10 @@ import hudson.model.UserProperty;
 import hudson.model.UserPropertyDescriptor;
 import io.jenkins.plugins.akeyless.synced.auth.SyncedAuthMethod;
 import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient;
+import java.util.List;
+import javax.annotation.Nullable;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
-
-import javax.annotation.Nullable;
-import java.util.List;
 
 /**
  * Per-user Akeyless authentication (access ID + auth method). Shown on the user's Configure page when

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/config/AkeylessSyncedUserAuthProperty.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/config/AkeylessSyncedUserAuthProperty.java
@@ -1,0 +1,87 @@
+package io.jenkins.plugins.akeyless.synced.config;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.model.User;
+import hudson.model.UserProperty;
+import hudson.model.UserPropertyDescriptor;
+import io.jenkins.plugins.akeyless.synced.auth.SyncedAuthMethod;
+import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * Per-user Akeyless authentication (access ID + auth method). Shown on the user's Configure page when
+ * {@link AuthenticationScope#PER_USER} is selected in global plugin configuration.
+ */
+public class AkeylessSyncedUserAuthProperty extends UserProperty {
+
+    private String accessId;
+    private SyncedAuthMethod authMethod;
+
+    @DataBoundConstructor
+    public AkeylessSyncedUserAuthProperty() {}
+
+    public String getAccessId() {
+        return accessId;
+    }
+
+    @DataBoundSetter
+    public void setAccessId(String accessId) {
+        this.accessId = accessId;
+    }
+
+    public SyncedAuthMethod getAuthMethod() {
+        return authMethod;
+    }
+
+    @DataBoundSetter
+    public void setAuthMethod(SyncedAuthMethod authMethod) {
+        this.authMethod = authMethod;
+    }
+
+    public boolean isConfigured() {
+        return authMethod != null && authMethod.isConfigured(accessId);
+    }
+
+    @Nullable
+    public AkeylessSyncedClient buildClient(String akeylessUrl) {
+        if (!isConfigured() || akeylessUrl == null || akeylessUrl.isBlank()) {
+            return null;
+        }
+        return new AkeylessSyncedClient(akeylessUrl.trim(), accessId != null ? accessId.trim() : null, authMethod);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends UserPropertyDescriptor {
+
+        public DescriptorImpl() {
+            super(AkeylessSyncedUserAuthProperty.class);
+        }
+
+        @Override
+        public boolean isEnabled() {
+            AkeylessSyncedCredentialsProviderConfig config = AkeylessSyncedCredentialsProviderConfig.get();
+            return config != null && config.isPerUserAuthentication();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Akeyless authentication";
+        }
+
+        @Override
+        public UserProperty newInstance(User user) {
+            return new AkeylessSyncedUserAuthProperty();
+        }
+
+        public List<Descriptor<SyncedAuthMethod>> getAuthMethodDescriptors() {
+            return SyncedAuthMethod.all().stream()
+                    .map(d -> (Descriptor<SyncedAuthMethod>) d)
+                    .toList();
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/config/AuthenticationScope.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/config/AuthenticationScope.java
@@ -4,34 +4,34 @@ package io.jenkins.plugins.akeyless.synced.config;
  * Whether Akeyless API authentication is configured once globally (admin) or per Jenkins user.
  */
 public enum AuthenticationScope {
-  /** Single auth method on Manage Jenkins → Configure System (current default). */
-  GLOBAL("Global (single service account)"),
-  /** Each user configures Akeyless auth on their profile; secrets sync with that user's Akeyless permissions. */
-  PER_USER("Per Jenkins user");
+    /** Single auth method on Manage Jenkins → Configure System (current default). */
+    GLOBAL("Global (single service account)"),
+    /** Each user configures Akeyless auth on their profile; secrets sync with that user's Akeyless permissions. */
+    PER_USER("Per Jenkins user");
 
-  private final String displayName;
+    private final String displayName;
 
-  AuthenticationScope(String displayName) {
-    this.displayName = displayName;
-  }
-
-  public static AuthenticationScope fromString(String value) {
-    if (value == null || value.isBlank()) {
-      return GLOBAL;
+    AuthenticationScope(String displayName) {
+        this.displayName = displayName;
     }
-    try {
-      return AuthenticationScope.valueOf(value.trim());
-    } catch (IllegalArgumentException e) {
-      return GLOBAL;
+
+    public static AuthenticationScope fromString(String value) {
+        if (value == null || value.isBlank()) {
+            return GLOBAL;
+        }
+        try {
+            return AuthenticationScope.valueOf(value.trim());
+        } catch (IllegalArgumentException e) {
+            return GLOBAL;
+        }
     }
-  }
 
-  public boolean isPerUser() {
-    return this == PER_USER;
-  }
+    public boolean isPerUser() {
+        return this == PER_USER;
+    }
 
-  @Override
-  public String toString() {
-    return displayName;
-  }
+    @Override
+    public String toString() {
+        return displayName;
+    }
 }

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/config/AuthenticationScope.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/config/AuthenticationScope.java
@@ -1,0 +1,37 @@
+package io.jenkins.plugins.akeyless.synced.config;
+
+/**
+ * Whether Akeyless API authentication is configured once globally (admin) or per Jenkins user.
+ */
+public enum AuthenticationScope {
+  /** Single auth method on Manage Jenkins → Configure System (current default). */
+  GLOBAL("Global (single service account)"),
+  /** Each user configures Akeyless auth on their profile; secrets sync with that user's Akeyless permissions. */
+  PER_USER("Per Jenkins user");
+
+  private final String displayName;
+
+  AuthenticationScope(String displayName) {
+    this.displayName = displayName;
+  }
+
+  public static AuthenticationScope fromString(String value) {
+    if (value == null || value.isBlank()) {
+      return GLOBAL;
+    }
+    try {
+      return AuthenticationScope.valueOf(value.trim());
+    } catch (IllegalArgumentException e) {
+      return GLOBAL;
+    }
+  }
+
+  public boolean isPerUser() {
+    return this == PER_USER;
+  }
+
+  @Override
+  public String toString() {
+    return displayName;
+  }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/config/FolderPathRules.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/config/FolderPathRules.java
@@ -1,0 +1,27 @@
+package io.jenkins.plugins.akeyless.synced.config;
+
+import javax.annotation.Nullable;
+
+/** Validation for folder-path configuration used with list-items discovery. */
+public final class FolderPathRules {
+
+    private FolderPathRules() {}
+
+    /**
+     * {@code '/'} alone (or repeated slashes only) resolves to listing the entire vault — disallowed on purpose.
+     */
+    public static boolean isForbiddenRootFolder(@Nullable String folderPathRaw) {
+        if (folderPathRaw == null) {
+            return false;
+        }
+        String t = folderPathRaw.trim();
+        if (t.isEmpty()) {
+            return false;
+        }
+        t = t.replaceAll("/+", "/");
+        while (t.length() > 1 && t.endsWith("/")) {
+            t = t.substring(0, t.length() - 1);
+        }
+        return "/".equals(t);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/config/scope/AuthenticationScopeMode.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/config/scope/AuthenticationScopeMode.java
@@ -1,0 +1,19 @@
+package io.jenkins.plugins.akeyless.synced.config.scope;
+
+import hudson.DescriptorExtensionList;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import jenkins.model.Jenkins;
+
+/**
+ * How Jenkins authenticates to Akeyless: one global identity or per Jenkins user.
+ * Rendered with {@code f:dropdownDescriptorSelector} (same as {@link io.jenkins.plugins.akeyless.synced.auth.SyncedAuthMethod}).
+ */
+public abstract class AuthenticationScopeMode extends AbstractDescribableImpl<AuthenticationScopeMode> {
+
+    public abstract boolean isPerUser();
+
+    public static DescriptorExtensionList<AuthenticationScopeMode, Descriptor<AuthenticationScopeMode>> all() {
+        return Jenkins.get().getDescriptorList(AuthenticationScopeMode.class);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/config/scope/GlobalAuthenticationScopeMode.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/config/scope/GlobalAuthenticationScopeMode.java
@@ -1,0 +1,24 @@
+package io.jenkins.plugins.akeyless.synced.config.scope;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class GlobalAuthenticationScopeMode extends AuthenticationScopeMode {
+
+    @DataBoundConstructor
+    public GlobalAuthenticationScopeMode() {}
+
+    @Override
+    public boolean isPerUser() {
+        return false;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends Descriptor<AuthenticationScopeMode> {
+        @Override
+        public String getDisplayName() {
+            return "Global (single service account)";
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/config/scope/PerUserAuthenticationScopeMode.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/config/scope/PerUserAuthenticationScopeMode.java
@@ -1,0 +1,24 @@
+package io.jenkins.plugins.akeyless.synced.config.scope;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class PerUserAuthenticationScopeMode extends AuthenticationScopeMode {
+
+    @DataBoundConstructor
+    public PerUserAuthenticationScopeMode() {}
+
+    @Override
+    public boolean isPerUser() {
+        return true;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends Descriptor<AuthenticationScopeMode> {
+        @Override
+        public String getDisplayName() {
+            return "Per Jenkins user";
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedCertificateCredentials.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedCertificateCredentials.java
@@ -2,23 +2,24 @@ package io.jenkins.plugins.akeyless.synced.credentials;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsUnavailableException;
-import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.util.Secret;
 import io.akeyless.client.ApiException;
 import io.jenkins.plugins.akeyless.synced.AkeylessSyncedCredentialsProvider;
-import io.jenkins.plugins.akeyless.synced.client.PemPkcs12Util;
 import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient;
 import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient.GetSecretValueResult;
-
-import javax.annotation.Nullable;
-
+import io.jenkins.plugins.akeyless.synced.client.PemPkcs12Util;
 import java.io.ByteArrayInputStream;
 import java.security.KeyStore;
+import javax.annotation.Nullable;
 
-public class AkeylessSyncedCertificateCredentials extends AkeylessSyncedCredentialBase implements StandardCertificateCredentials {
+public class AkeylessSyncedCertificateCredentials extends AkeylessSyncedCredentialBase
+        implements StandardCertificateCredentials {
+
+    private static final long serialVersionUID = 1L;
 
     private final String akeylessPath;
 
@@ -26,7 +27,8 @@ public class AkeylessSyncedCertificateCredentials extends AkeylessSyncedCredenti
         this(id, akeylessPath, description, null);
     }
 
-    public AkeylessSyncedCertificateCredentials(String id, String akeylessPath, String description, @Nullable String ownerUserId) {
+    public AkeylessSyncedCertificateCredentials(
+            String id, String akeylessPath, String description, @Nullable String ownerUserId) {
         super(id, description, ownerUserId);
         this.akeylessPath = akeylessPath != null ? akeylessPath : id;
     }
@@ -41,7 +43,8 @@ public class AkeylessSyncedCertificateCredentials extends AkeylessSyncedCredenti
             if (r.isPemCertificatePair()) {
                 return PemPkcs12Util.buildPkcs12KeyStore(r.getCertificatePem(), r.getPrivateKeyPem(), ksPassword);
             }
-            byte[] bytes = r.getBinaryValue() != null ? r.getBinaryValue()
+            byte[] bytes = r.getBinaryValue() != null
+                    ? r.getBinaryValue()
                     : r.getStringValue().getBytes(java.nio.charset.StandardCharsets.UTF_8);
             KeyStore ks = KeyStore.getInstance("PKCS12");
             ks.load(new ByteArrayInputStream(bytes), ksPassword);
@@ -63,7 +66,9 @@ public class AkeylessSyncedCertificateCredentials extends AkeylessSyncedCredenti
     public static class DescriptorImpl extends BaseStandardCredentials.BaseStandardCredentialsDescriptor {
         @Override
         @NonNull
-        public String getDisplayName() { return "Akeyless Certificate"; }
+        public String getDisplayName() {
+            return "Akeyless Certificate";
+        }
 
         @Override
         public boolean isApplicable(CredentialsProvider scope) {

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedCertificateCredentials.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedCertificateCredentials.java
@@ -1,0 +1,73 @@
+package io.jenkins.plugins.akeyless.synced.credentials;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsUnavailableException;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.util.Secret;
+import io.akeyless.client.ApiException;
+import io.jenkins.plugins.akeyless.synced.AkeylessSyncedCredentialsProvider;
+import io.jenkins.plugins.akeyless.synced.client.PemPkcs12Util;
+import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient;
+import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient.GetSecretValueResult;
+
+import javax.annotation.Nullable;
+
+import java.io.ByteArrayInputStream;
+import java.security.KeyStore;
+
+public class AkeylessSyncedCertificateCredentials extends AkeylessSyncedCredentialBase implements StandardCertificateCredentials {
+
+    private final String akeylessPath;
+
+    public AkeylessSyncedCertificateCredentials(String id, String akeylessPath, String description) {
+        this(id, akeylessPath, description, null);
+    }
+
+    public AkeylessSyncedCertificateCredentials(String id, String akeylessPath, String description, @Nullable String ownerUserId) {
+        super(id, description, ownerUserId);
+        this.akeylessPath = akeylessPath != null ? akeylessPath : id;
+    }
+
+    @NonNull
+    @Override
+    public KeyStore getKeyStore() {
+        AkeylessSyncedClient client = requireClient();
+        try {
+            GetSecretValueResult r = client.getSecretValue(akeylessPath);
+            char[] ksPassword = getPassword().getPlainText().toCharArray();
+            if (r.isPemCertificatePair()) {
+                return PemPkcs12Util.buildPkcs12KeyStore(r.getCertificatePem(), r.getPrivateKeyPem(), ksPassword);
+            }
+            byte[] bytes = r.getBinaryValue() != null ? r.getBinaryValue()
+                    : r.getStringValue().getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            KeyStore ks = KeyStore.getInstance("PKCS12");
+            ks.load(new ByteArrayInputStream(bytes), ksPassword);
+            return ks;
+        } catch (ApiException e) {
+            throw new CredentialsUnavailableException("Could not retrieve secret from Akeyless: " + e.getMessage(), e);
+        } catch (Exception e) {
+            throw new CredentialsUnavailableException("Could not load keystore: " + e.getMessage(), e);
+        }
+    }
+
+    @NonNull
+    @Override
+    public Secret getPassword() {
+        return Secret.fromString("");
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BaseStandardCredentials.BaseStandardCredentialsDescriptor {
+        @Override
+        @NonNull
+        public String getDisplayName() { return "Akeyless Certificate"; }
+
+        @Override
+        public boolean isApplicable(CredentialsProvider scope) {
+            return scope instanceof AkeylessSyncedCredentialsProvider;
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedCredentialBase.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedCredentialBase.java
@@ -5,7 +5,6 @@ import com.cloudbees.plugins.credentials.CredentialsUnavailableException;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedAuthResolver;
 import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient;
-
 import javax.annotation.Nullable;
 
 /**
@@ -13,6 +12,8 @@ import javax.annotation.Nullable;
  * is per-user so secret fetches use that user's Akeyless identity.
  */
 public abstract class AkeylessSyncedCredentialBase extends BaseStandardCredentials {
+
+    private static final long serialVersionUID = 1L;
 
     @Nullable
     private final String ownerUserId;

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedCredentialBase.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedCredentialBase.java
@@ -1,0 +1,44 @@
+package io.jenkins.plugins.akeyless.synced.credentials;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsUnavailableException;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedAuthResolver;
+import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient;
+
+import javax.annotation.Nullable;
+
+/**
+ * Base for Akeyless-backed credentials synced into Jenkins. {@code ownerUserId} is set when authentication scope
+ * is per-user so secret fetches use that user's Akeyless identity.
+ */
+public abstract class AkeylessSyncedCredentialBase extends BaseStandardCredentials {
+
+    @Nullable
+    private final String ownerUserId;
+
+    protected AkeylessSyncedCredentialBase(String id, String description, @Nullable String ownerUserId) {
+        super(ownerUserId != null ? CredentialsScope.USER : CredentialsScope.GLOBAL, id, description);
+        this.ownerUserId = ownerUserId;
+    }
+
+    @Nullable
+    public String getOwnerUserId() {
+        return ownerUserId;
+    }
+
+    protected static AkeylessSyncedClient requireClient(@Nullable String ownerUserId) {
+        AkeylessSyncedClient client = AkeylessSyncedAuthResolver.resolveClient(ownerUserId);
+        if (client == null) {
+            throw new CredentialsUnavailableException(
+                    ownerUserId != null
+                            ? "Akeyless Credentials Provider: user authentication is not configured"
+                            : "Akeyless Credentials Provider is not configured");
+        }
+        return client;
+    }
+
+    protected AkeylessSyncedClient requireClient() {
+        return requireClient(ownerUserId);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedFileCredentials.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedFileCredentials.java
@@ -1,0 +1,65 @@
+package io.jenkins.plugins.akeyless.synced.credentials;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsUnavailableException;
+import com.cloudbees.plugins.credentials.SecretBytes;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import io.akeyless.client.ApiException;
+import io.jenkins.plugins.akeyless.synced.AkeylessSyncedCredentialsProvider;
+import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient;
+import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient.GetSecretValueResult;
+
+import javax.annotation.Nullable;
+
+public class AkeylessSyncedFileCredentials extends AkeylessSyncedCredentialBase implements StandardCredentials {
+
+    private final String akeylessPath;
+    private final String filename;
+
+    public AkeylessSyncedFileCredentials(String id, String akeylessPath, String description, String filename) {
+        this(id, akeylessPath, description, filename, null);
+    }
+
+    public AkeylessSyncedFileCredentials(String id, String akeylessPath, String description, String filename, @Nullable String ownerUserId) {
+        super(id, description, ownerUserId);
+        this.akeylessPath = akeylessPath != null ? akeylessPath : id;
+        this.filename = filename != null ? filename : id;
+    }
+
+    @NonNull
+    public String getFileName() {
+        return filename;
+    }
+
+    @NonNull
+    public SecretBytes getContent() {
+        AkeylessSyncedClient client = requireClient();
+        try {
+            GetSecretValueResult r = client.getSecretValue(akeylessPath);
+            if (r.isString()) {
+                return SecretBytes.fromBytes(r.getStringValue().getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            }
+            if (r.getBinaryValue() != null) {
+                return SecretBytes.fromBytes(r.getBinaryValue());
+            }
+            throw new CredentialsUnavailableException("Secret '" + akeylessPath + "' has no value");
+        } catch (ApiException e) {
+            throw new CredentialsUnavailableException("Could not retrieve secret from Akeyless: " + e.getMessage(), e);
+        }
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BaseStandardCredentials.BaseStandardCredentialsDescriptor {
+        @Override
+        @NonNull
+        public String getDisplayName() { return "Akeyless Secret File"; }
+
+        @Override
+        public boolean isApplicable(CredentialsProvider scope) {
+            return scope instanceof AkeylessSyncedCredentialsProvider;
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedFileCredentials.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedFileCredentials.java
@@ -11,10 +11,11 @@ import io.akeyless.client.ApiException;
 import io.jenkins.plugins.akeyless.synced.AkeylessSyncedCredentialsProvider;
 import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient;
 import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient.GetSecretValueResult;
-
 import javax.annotation.Nullable;
 
 public class AkeylessSyncedFileCredentials extends AkeylessSyncedCredentialBase implements StandardCredentials {
+
+    private static final long serialVersionUID = 1L;
 
     private final String akeylessPath;
     private final String filename;
@@ -23,7 +24,8 @@ public class AkeylessSyncedFileCredentials extends AkeylessSyncedCredentialBase 
         this(id, akeylessPath, description, filename, null);
     }
 
-    public AkeylessSyncedFileCredentials(String id, String akeylessPath, String description, String filename, @Nullable String ownerUserId) {
+    public AkeylessSyncedFileCredentials(
+            String id, String akeylessPath, String description, String filename, @Nullable String ownerUserId) {
         super(id, description, ownerUserId);
         this.akeylessPath = akeylessPath != null ? akeylessPath : id;
         this.filename = filename != null ? filename : id;
@@ -55,7 +57,9 @@ public class AkeylessSyncedFileCredentials extends AkeylessSyncedCredentialBase 
     public static class DescriptorImpl extends BaseStandardCredentials.BaseStandardCredentialsDescriptor {
         @Override
         @NonNull
-        public String getDisplayName() { return "Akeyless Secret File"; }
+        public String getDisplayName() {
+            return "Akeyless Secret File";
+        }
 
         @Override
         public boolean isApplicable(CredentialsProvider scope) {

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedSSHUserPrivateKeyCredentials.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedSSHUserPrivateKeyCredentials.java
@@ -11,13 +11,14 @@ import io.akeyless.client.ApiException;
 import io.jenkins.plugins.akeyless.synced.AkeylessSyncedCredentialsProvider;
 import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient;
 import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient.GetSecretValueResult;
-
-import javax.annotation.Nullable;
-
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
 
-public class AkeylessSyncedSSHUserPrivateKeyCredentials extends AkeylessSyncedCredentialBase implements SSHUserPrivateKey {
+public class AkeylessSyncedSSHUserPrivateKeyCredentials extends AkeylessSyncedCredentialBase
+        implements SSHUserPrivateKey {
+
+    private static final long serialVersionUID = 1L;
 
     private static final Secret NO_PASSPHRASE = Secret.fromString("");
 
@@ -27,12 +28,18 @@ public class AkeylessSyncedSSHUserPrivateKeyCredentials extends AkeylessSyncedCr
 
     private transient volatile SshParsed parsed;
 
-    public AkeylessSyncedSSHUserPrivateKeyCredentials(String id, String akeylessPath, String description, String usernameFromTag, String valueFormat) {
+    public AkeylessSyncedSSHUserPrivateKeyCredentials(
+            String id, String akeylessPath, String description, String usernameFromTag, String valueFormat) {
         this(id, akeylessPath, description, usernameFromTag, valueFormat, null);
     }
 
-    public AkeylessSyncedSSHUserPrivateKeyCredentials(String id, String akeylessPath, String description, String usernameFromTag, String valueFormat,
-                                                @Nullable String ownerUserId) {
+    public AkeylessSyncedSSHUserPrivateKeyCredentials(
+            String id,
+            String akeylessPath,
+            String description,
+            String usernameFromTag,
+            String valueFormat,
+            @Nullable String ownerUserId) {
         super(id, description, ownerUserId);
         this.akeylessPath = akeylessPath != null ? akeylessPath : id;
         this.usernameFromTag = usernameFromTag != null ? usernameFromTag : "";
@@ -75,7 +82,8 @@ public class AkeylessSyncedSSHUserPrivateKeyCredentials extends AkeylessSyncedCr
             try {
                 GetSecretValueResult r = client.getSecretValue(akeylessPath);
                 if (!r.isString()) {
-                    throw new CredentialsUnavailableException("Secret '" + akeylessPath + "' is binary, cannot use as SSH key");
+                    throw new CredentialsUnavailableException(
+                            "Secret '" + akeylessPath + "' is binary, cannot use as SSH key");
                 }
                 String raw = r.getStringValue();
                 boolean useJson = SecretJsonBodies.isJsonFormat(valueFormat)
@@ -83,7 +91,8 @@ public class AkeylessSyncedSSHUserPrivateKeyCredentials extends AkeylessSyncedCr
                 if (useJson) {
                     SecretJsonBodies.SshJson j = SecretJsonBodies.parseSsh(raw);
                     if (j == null) {
-                        throw new CredentialsUnavailableException("Secret '" + akeylessPath + "' JSON must include privateKey (and optionally username, passphrase) fields");
+                        throw new CredentialsUnavailableException("Secret '" + akeylessPath
+                                + "' JSON must include privateKey (and optionally username, passphrase) fields");
                     }
                     String user = !j.username.isEmpty() ? j.username : usernameFromTag;
                     Secret pass = j.passphrase.isEmpty() ? NO_PASSPHRASE : Secret.fromString(j.passphrase);
@@ -93,7 +102,8 @@ public class AkeylessSyncedSSHUserPrivateKeyCredentials extends AkeylessSyncedCr
                 }
                 return parsed;
             } catch (ApiException e) {
-                throw new CredentialsUnavailableException("Could not retrieve secret from Akeyless: " + e.getMessage(), e);
+                throw new CredentialsUnavailableException(
+                        "Could not retrieve secret from Akeyless: " + e.getMessage(), e);
             }
         }
     }
@@ -114,7 +124,9 @@ public class AkeylessSyncedSSHUserPrivateKeyCredentials extends AkeylessSyncedCr
     public static class DescriptorImpl extends BaseStandardCredentials.BaseStandardCredentialsDescriptor {
         @Override
         @NonNull
-        public String getDisplayName() { return "Akeyless SSH Private Key"; }
+        public String getDisplayName() {
+            return "Akeyless SSH Private Key";
+        }
 
         @Override
         public boolean isApplicable(CredentialsProvider scope) {

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedSSHUserPrivateKeyCredentials.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedSSHUserPrivateKeyCredentials.java
@@ -1,0 +1,124 @@
+package io.jenkins.plugins.akeyless.synced.credentials;
+
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsUnavailableException;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.util.Secret;
+import io.akeyless.client.ApiException;
+import io.jenkins.plugins.akeyless.synced.AkeylessSyncedCredentialsProvider;
+import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient;
+import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient.GetSecretValueResult;
+
+import javax.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+
+public class AkeylessSyncedSSHUserPrivateKeyCredentials extends AkeylessSyncedCredentialBase implements SSHUserPrivateKey {
+
+    private static final Secret NO_PASSPHRASE = Secret.fromString("");
+
+    private final String akeylessPath;
+    private final String usernameFromTag;
+    private final String valueFormat;
+
+    private transient volatile SshParsed parsed;
+
+    public AkeylessSyncedSSHUserPrivateKeyCredentials(String id, String akeylessPath, String description, String usernameFromTag, String valueFormat) {
+        this(id, akeylessPath, description, usernameFromTag, valueFormat, null);
+    }
+
+    public AkeylessSyncedSSHUserPrivateKeyCredentials(String id, String akeylessPath, String description, String usernameFromTag, String valueFormat,
+                                                @Nullable String ownerUserId) {
+        super(id, description, ownerUserId);
+        this.akeylessPath = akeylessPath != null ? akeylessPath : id;
+        this.usernameFromTag = usernameFromTag != null ? usernameFromTag : "";
+        this.valueFormat = valueFormat != null ? valueFormat : "";
+    }
+
+    @NonNull
+    @Override
+    public String getUsername() {
+        return load().username;
+    }
+
+    @Override
+    @Deprecated
+    public String getPrivateKey() {
+        return getPrivateKeys().isEmpty() ? "" : getPrivateKeys().get(0);
+    }
+
+    @Override
+    public Secret getPassphrase() {
+        return load().passphrase;
+    }
+
+    @NonNull
+    @Override
+    public List<String> getPrivateKeys() {
+        return Collections.singletonList(load().privateKey);
+    }
+
+    private SshParsed load() {
+        SshParsed p = parsed;
+        if (p != null) {
+            return p;
+        }
+        synchronized (this) {
+            if (parsed != null) {
+                return parsed;
+            }
+            AkeylessSyncedClient client = requireClient();
+            try {
+                GetSecretValueResult r = client.getSecretValue(akeylessPath);
+                if (!r.isString()) {
+                    throw new CredentialsUnavailableException("Secret '" + akeylessPath + "' is binary, cannot use as SSH key");
+                }
+                String raw = r.getStringValue();
+                boolean useJson = SecretJsonBodies.isJsonFormat(valueFormat)
+                        || (valueFormat.isEmpty() && SecretJsonBodies.looksLikeJsonObject(raw));
+                if (useJson) {
+                    SecretJsonBodies.SshJson j = SecretJsonBodies.parseSsh(raw);
+                    if (j == null) {
+                        throw new CredentialsUnavailableException("Secret '" + akeylessPath + "' JSON must include privateKey (and optionally username, passphrase) fields");
+                    }
+                    String user = !j.username.isEmpty() ? j.username : usernameFromTag;
+                    Secret pass = j.passphrase.isEmpty() ? NO_PASSPHRASE : Secret.fromString(j.passphrase);
+                    parsed = new SshParsed(user, j.privateKey, pass);
+                } else {
+                    parsed = new SshParsed(usernameFromTag, raw, NO_PASSPHRASE);
+                }
+                return parsed;
+            } catch (ApiException e) {
+                throw new CredentialsUnavailableException("Could not retrieve secret from Akeyless: " + e.getMessage(), e);
+            }
+        }
+    }
+
+    private static final class SshParsed {
+        final String username;
+        final String privateKey;
+        final Secret passphrase;
+
+        SshParsed(String username, String privateKey, Secret passphrase) {
+            this.username = username != null ? username : "";
+            this.privateKey = privateKey != null ? privateKey : "";
+            this.passphrase = passphrase != null ? passphrase : NO_PASSPHRASE;
+        }
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BaseStandardCredentials.BaseStandardCredentialsDescriptor {
+        @Override
+        @NonNull
+        public String getDisplayName() { return "Akeyless SSH Private Key"; }
+
+        @Override
+        public boolean isApplicable(CredentialsProvider scope) {
+            return scope instanceof AkeylessSyncedCredentialsProvider;
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedStringCredentials.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedStringCredentials.java
@@ -1,0 +1,72 @@
+package io.jenkins.plugins.akeyless.synced.credentials;
+
+import com.cloudbees.plugins.credentials.CredentialsUnavailableException;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.util.Secret;
+import io.akeyless.client.ApiException;
+import io.jenkins.plugins.akeyless.synced.AkeylessSyncedCredentialsProvider;
+import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient;
+import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient.GetSecretValueResult;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+
+import javax.annotation.Nullable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class AkeylessSyncedStringCredentials extends AkeylessSyncedCredentialBase implements StringCredentials {
+
+    private static final Logger LOG = Logger.getLogger(AkeylessSyncedStringCredentials.class.getName());
+
+    private final String akeylessPath;
+
+    public AkeylessSyncedStringCredentials(String id, String akeylessPath, String description) {
+        this(id, akeylessPath, description, null);
+    }
+
+    public AkeylessSyncedStringCredentials(String id, String akeylessPath, String description, @Nullable String ownerUserId) {
+        super(id, description, ownerUserId);
+        this.akeylessPath = akeylessPath != null ? akeylessPath : id;
+    }
+
+    @NonNull
+    public Secret getSecret() {
+        AkeylessSyncedClient client = requireClient();
+        try {
+            LOG.log(Level.INFO, "Akeyless Credentials Provider: fetching secret value for credential id={0} path={1}", new Object[]{getId(), akeylessPath});
+            GetSecretValueResult r = client.getSecretValue(akeylessPath);
+            if (r.isString()) {
+                return Secret.fromString(r.getStringValue());
+            }
+            throw new CredentialsUnavailableException("Secret '" + akeylessPath + "' is binary, cannot use as string");
+        } catch (ApiException e) {
+            LOG.log(Level.WARNING, "Akeyless Credentials Provider: failed to get secret for path={0}: {1}", new Object[]{akeylessPath, e.getMessage()});
+            throw new CredentialsUnavailableException("Could not retrieve secret from Akeyless: " + e.getMessage(), e);
+        }
+    }
+
+    /** @deprecated use {@link AkeylessSyncedCredentialBase#requireClient(String)} */
+    @Deprecated
+    static AkeylessSyncedClient getClient() {
+        return requireClient(null);
+    }
+
+    static AkeylessSyncedClient getClient(@Nullable String ownerUserId) {
+        return requireClient(ownerUserId);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
+        @Override
+        @NonNull
+        public String getDisplayName() { return "Akeyless Secret Text"; }
+
+        @Override
+        public boolean isApplicable(CredentialsProvider scope) {
+            return scope instanceof AkeylessSyncedCredentialsProvider;
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedStringCredentials.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedStringCredentials.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.akeyless.synced.credentials;
 
+import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsUnavailableException;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
@@ -8,16 +9,14 @@ import io.akeyless.client.ApiException;
 import io.jenkins.plugins.akeyless.synced.AkeylessSyncedCredentialsProvider;
 import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient;
 import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient.GetSecretValueResult;
-
-import com.cloudbees.plugins.credentials.CredentialsProvider;
-import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
-import org.jenkinsci.plugins.plaincredentials.StringCredentials;
-
-import javax.annotation.Nullable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 public class AkeylessSyncedStringCredentials extends AkeylessSyncedCredentialBase implements StringCredentials {
+
+    private static final long serialVersionUID = 1L;
 
     private static final Logger LOG = Logger.getLogger(AkeylessSyncedStringCredentials.class.getName());
 
@@ -27,7 +26,8 @@ public class AkeylessSyncedStringCredentials extends AkeylessSyncedCredentialBas
         this(id, akeylessPath, description, null);
     }
 
-    public AkeylessSyncedStringCredentials(String id, String akeylessPath, String description, @Nullable String ownerUserId) {
+    public AkeylessSyncedStringCredentials(
+            String id, String akeylessPath, String description, @Nullable String ownerUserId) {
         super(id, description, ownerUserId);
         this.akeylessPath = akeylessPath != null ? akeylessPath : id;
     }
@@ -36,14 +36,20 @@ public class AkeylessSyncedStringCredentials extends AkeylessSyncedCredentialBas
     public Secret getSecret() {
         AkeylessSyncedClient client = requireClient();
         try {
-            LOG.log(Level.INFO, "Akeyless Credentials Provider: fetching secret value for credential id={0} path={1}", new Object[]{getId(), akeylessPath});
+            LOG.log(
+                    Level.INFO,
+                    "Akeyless Credentials Provider: fetching secret value for credential id={0} path={1}",
+                    new Object[] {getId(), akeylessPath});
             GetSecretValueResult r = client.getSecretValue(akeylessPath);
             if (r.isString()) {
                 return Secret.fromString(r.getStringValue());
             }
             throw new CredentialsUnavailableException("Secret '" + akeylessPath + "' is binary, cannot use as string");
         } catch (ApiException e) {
-            LOG.log(Level.WARNING, "Akeyless Credentials Provider: failed to get secret for path={0}: {1}", new Object[]{akeylessPath, e.getMessage()});
+            LOG.log(
+                    Level.WARNING,
+                    "Akeyless Credentials Provider: failed to get secret for path={0}: {1}",
+                    new Object[] {akeylessPath, e.getMessage()});
             throw new CredentialsUnavailableException("Could not retrieve secret from Akeyless: " + e.getMessage(), e);
         }
     }
@@ -62,7 +68,9 @@ public class AkeylessSyncedStringCredentials extends AkeylessSyncedCredentialBas
     public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
         @Override
         @NonNull
-        public String getDisplayName() { return "Akeyless Secret Text"; }
+        public String getDisplayName() {
+            return "Akeyless Secret Text";
+        }
 
         @Override
         public boolean isApplicable(CredentialsProvider scope) {

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedUsernamePasswordCredentials.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedUsernamePasswordCredentials.java
@@ -11,10 +11,12 @@ import io.akeyless.client.ApiException;
 import io.jenkins.plugins.akeyless.synced.AkeylessSyncedCredentialsProvider;
 import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient;
 import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient.GetSecretValueResult;
-
 import javax.annotation.Nullable;
 
-public class AkeylessSyncedUsernamePasswordCredentials extends AkeylessSyncedCredentialBase implements StandardUsernamePasswordCredentials {
+public class AkeylessSyncedUsernamePasswordCredentials extends AkeylessSyncedCredentialBase
+        implements StandardUsernamePasswordCredentials {
+
+    private static final long serialVersionUID = 1L;
 
     private final String akeylessPath;
     private final String usernameFromTag;
@@ -22,12 +24,18 @@ public class AkeylessSyncedUsernamePasswordCredentials extends AkeylessSyncedCre
 
     private transient volatile Parsed parsed;
 
-    public AkeylessSyncedUsernamePasswordCredentials(String id, String akeylessPath, String description, String usernameFromTag, String valueFormat) {
+    public AkeylessSyncedUsernamePasswordCredentials(
+            String id, String akeylessPath, String description, String usernameFromTag, String valueFormat) {
         this(id, akeylessPath, description, usernameFromTag, valueFormat, null);
     }
 
-    public AkeylessSyncedUsernamePasswordCredentials(String id, String akeylessPath, String description, String usernameFromTag, String valueFormat,
-                                               @Nullable String ownerUserId) {
+    public AkeylessSyncedUsernamePasswordCredentials(
+            String id,
+            String akeylessPath,
+            String description,
+            String usernameFromTag,
+            String valueFormat,
+            @Nullable String ownerUserId) {
         super(id, description, ownerUserId);
         this.akeylessPath = akeylessPath != null ? akeylessPath : id;
         this.usernameFromTag = usernameFromTag != null ? usernameFromTag : "";
@@ -59,7 +67,8 @@ public class AkeylessSyncedUsernamePasswordCredentials extends AkeylessSyncedCre
             try {
                 GetSecretValueResult r = client.getSecretValue(akeylessPath);
                 if (!r.isString()) {
-                    throw new CredentialsUnavailableException("Secret '" + akeylessPath + "' is binary, cannot use as password");
+                    throw new CredentialsUnavailableException(
+                            "Secret '" + akeylessPath + "' is binary, cannot use as password");
                 }
                 String raw = r.getStringValue();
                 boolean useJson = SecretJsonBodies.isJsonFormat(valueFormat)
@@ -67,7 +76,8 @@ public class AkeylessSyncedUsernamePasswordCredentials extends AkeylessSyncedCre
                 if (useJson) {
                     SecretJsonBodies.UsernamePasswordJson j = SecretJsonBodies.parseUsernamePassword(raw);
                     if (j == null) {
-                        throw new CredentialsUnavailableException("Secret '" + akeylessPath + "' JSON must include password (and optionally username) fields");
+                        throw new CredentialsUnavailableException("Secret '" + akeylessPath
+                                + "' JSON must include password (and optionally username) fields");
                     }
                     String user = !j.username.isEmpty() ? j.username : usernameFromTag;
                     parsed = new Parsed(user, Secret.fromString(j.password));
@@ -76,7 +86,8 @@ public class AkeylessSyncedUsernamePasswordCredentials extends AkeylessSyncedCre
                 }
                 return parsed;
             } catch (ApiException e) {
-                throw new CredentialsUnavailableException("Could not retrieve secret from Akeyless: " + e.getMessage(), e);
+                throw new CredentialsUnavailableException(
+                        "Could not retrieve secret from Akeyless: " + e.getMessage(), e);
             }
         }
     }
@@ -95,7 +106,9 @@ public class AkeylessSyncedUsernamePasswordCredentials extends AkeylessSyncedCre
     public static class DescriptorImpl extends BaseStandardCredentials.BaseStandardCredentialsDescriptor {
         @Override
         @NonNull
-        public String getDisplayName() { return "Akeyless Username/Password"; }
+        public String getDisplayName() {
+            return "Akeyless Username/Password";
+        }
 
         @Override
         public boolean isApplicable(CredentialsProvider scope) {

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedUsernamePasswordCredentials.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/AkeylessSyncedUsernamePasswordCredentials.java
@@ -1,0 +1,105 @@
+package io.jenkins.plugins.akeyless.synced.credentials;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsUnavailableException;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.util.Secret;
+import io.akeyless.client.ApiException;
+import io.jenkins.plugins.akeyless.synced.AkeylessSyncedCredentialsProvider;
+import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient;
+import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient.GetSecretValueResult;
+
+import javax.annotation.Nullable;
+
+public class AkeylessSyncedUsernamePasswordCredentials extends AkeylessSyncedCredentialBase implements StandardUsernamePasswordCredentials {
+
+    private final String akeylessPath;
+    private final String usernameFromTag;
+    private final String valueFormat;
+
+    private transient volatile Parsed parsed;
+
+    public AkeylessSyncedUsernamePasswordCredentials(String id, String akeylessPath, String description, String usernameFromTag, String valueFormat) {
+        this(id, akeylessPath, description, usernameFromTag, valueFormat, null);
+    }
+
+    public AkeylessSyncedUsernamePasswordCredentials(String id, String akeylessPath, String description, String usernameFromTag, String valueFormat,
+                                               @Nullable String ownerUserId) {
+        super(id, description, ownerUserId);
+        this.akeylessPath = akeylessPath != null ? akeylessPath : id;
+        this.usernameFromTag = usernameFromTag != null ? usernameFromTag : "";
+        this.valueFormat = valueFormat != null ? valueFormat : "";
+    }
+
+    @NonNull
+    @Override
+    public String getUsername() {
+        return load().username;
+    }
+
+    @NonNull
+    @Override
+    public Secret getPassword() {
+        return load().password;
+    }
+
+    private Parsed load() {
+        Parsed p = parsed;
+        if (p != null) {
+            return p;
+        }
+        synchronized (this) {
+            if (parsed != null) {
+                return parsed;
+            }
+            AkeylessSyncedClient client = requireClient();
+            try {
+                GetSecretValueResult r = client.getSecretValue(akeylessPath);
+                if (!r.isString()) {
+                    throw new CredentialsUnavailableException("Secret '" + akeylessPath + "' is binary, cannot use as password");
+                }
+                String raw = r.getStringValue();
+                boolean useJson = SecretJsonBodies.isJsonFormat(valueFormat)
+                        || (valueFormat.isEmpty() && SecretJsonBodies.looksLikeJsonObject(raw));
+                if (useJson) {
+                    SecretJsonBodies.UsernamePasswordJson j = SecretJsonBodies.parseUsernamePassword(raw);
+                    if (j == null) {
+                        throw new CredentialsUnavailableException("Secret '" + akeylessPath + "' JSON must include password (and optionally username) fields");
+                    }
+                    String user = !j.username.isEmpty() ? j.username : usernameFromTag;
+                    parsed = new Parsed(user, Secret.fromString(j.password));
+                } else {
+                    parsed = new Parsed(usernameFromTag, Secret.fromString(raw));
+                }
+                return parsed;
+            } catch (ApiException e) {
+                throw new CredentialsUnavailableException("Could not retrieve secret from Akeyless: " + e.getMessage(), e);
+            }
+        }
+    }
+
+    private static final class Parsed {
+        final String username;
+        final Secret password;
+
+        Parsed(String username, Secret password) {
+            this.username = username != null ? username : "";
+            this.password = password;
+        }
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BaseStandardCredentials.BaseStandardCredentialsDescriptor {
+        @Override
+        @NonNull
+        public String getDisplayName() { return "Akeyless Username/Password"; }
+
+        @Override
+        public boolean isApplicable(CredentialsProvider scope) {
+            return scope instanceof AkeylessSyncedCredentialsProvider;
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/SecretJsonBodies.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/SecretJsonBodies.java
@@ -3,7 +3,6 @@ package io.jenkins.plugins.akeyless.synced.credentials;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-
 import javax.annotation.Nullable;
 
 /**

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/SecretJsonBodies.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/credentials/SecretJsonBodies.java
@@ -1,0 +1,102 @@
+package io.jenkins.plugins.akeyless.synced.credentials;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import javax.annotation.Nullable;
+
+/**
+ * Parses JSON secret values when {@code jenkins:credentials:valueFormat=json} is set on the Akeyless item.
+ */
+final class SecretJsonBodies {
+
+    private SecretJsonBodies() {}
+
+    static boolean isJsonFormat(String valueFormat) {
+        return valueFormat != null && "json".equalsIgnoreCase(valueFormat.trim());
+    }
+
+    static boolean looksLikeJsonObject(String raw) {
+        return raw != null && raw.trim().startsWith("{");
+    }
+
+    @Nullable
+    static UsernamePasswordJson parseUsernamePassword(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            JsonElement el = JsonParser.parseString(raw.trim());
+            if (!el.isJsonObject()) {
+                return null;
+            }
+            JsonObject o = el.getAsJsonObject();
+            String user = firstString(o, "username", "user", "usr");
+            String pass = firstString(o, "password", "psw", "secret", "passwd");
+            if (pass == null) {
+                return null;
+            }
+            return new UsernamePasswordJson(user != null ? user : "", pass);
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    @Nullable
+    static SshJson parseSsh(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            JsonElement el = JsonParser.parseString(raw.trim());
+            if (!el.isJsonObject()) {
+                return null;
+            }
+            JsonObject o = el.getAsJsonObject();
+            String user = firstString(o, "username", "user", "usr");
+            String key = firstString(o, "privateKey", "private_key", "key");
+            if (key == null) {
+                return null;
+            }
+            String pass = firstString(o, "passphrase", "pass", "password");
+            return new SshJson(user != null ? user : "", key, pass != null ? pass : "");
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    private static String firstString(JsonObject o, String... keys) {
+        for (String k : keys) {
+            if (o.has(k) && o.get(k).isJsonPrimitive()) {
+                String s = o.get(k).getAsString();
+                if (s != null && !s.isEmpty()) {
+                    return s;
+                }
+            }
+        }
+        return null;
+    }
+
+    static final class UsernamePasswordJson {
+        final String username;
+        final String password;
+
+        UsernamePasswordJson(String username, String password) {
+            this.username = username;
+            this.password = password;
+        }
+    }
+
+    static final class SshJson {
+        final String username;
+        final String privateKey;
+        final String passphrase;
+
+        SshJson(String username, String privateKey, String passphrase) {
+            this.username = username;
+            this.privateKey = privateKey;
+            this.passphrase = passphrase;
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/factory/SyncedCredentialTags.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/factory/SyncedCredentialTags.java
@@ -1,0 +1,22 @@
+package io.jenkins.plugins.akeyless.synced.factory;
+
+/**
+ * Tag keys on Akeyless items used to map to Jenkins credential types (same convention as AWS Secrets Manager Credentials Provider).
+ *
+ * @see <a href="https://plugins.jenkins.io/aws-secrets-manager-credentials-provider/">AWS Secrets Manager Credentials Provider</a>
+ */
+public abstract class SyncedCredentialTags {
+    private static final String NAMESPACE = "jenkins:credentials:";
+
+    public static final String FILENAME = NAMESPACE + "filename";
+    public static final String TYPE = NAMESPACE + "type";
+    public static final String USERNAME = NAMESPACE + "username";
+    /**
+     * Optional. For {@code usernamePassword} / {@code sshUserPrivateKey} when the secret value is JSON:
+     * set to {@code json} to parse username/password (or username/privateKey) from the secret body.
+     * When unset, username comes from {@link #USERNAME} tag and the whole secret body is the password (or private key).
+     */
+    public static final String VALUE_FORMAT = NAMESPACE + "valueFormat";
+
+    private SyncedCredentialTags() {}
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/factory/SyncedCredentialType.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/factory/SyncedCredentialType.java
@@ -1,0 +1,14 @@
+package io.jenkins.plugins.akeyless.synced.factory;
+
+/**
+ * Jenkins credential type values for tag jenkins:credentials:type.
+ */
+public abstract class SyncedCredentialType {
+    public static final String STRING = "string";
+    public static final String USERNAME_PASSWORD = "usernamePassword";
+    public static final String SSH_USER_PRIVATE_KEY = "sshUserPrivateKey";
+    public static final String CERTIFICATE = "certificate";
+    public static final String FILE = "file";
+
+    private SyncedCredentialType() {}
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/factory/SyncedCredentialsFactory.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/factory/SyncedCredentialsFactory.java
@@ -1,0 +1,65 @@
+package io.jenkins.plugins.akeyless.synced.factory;
+
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import io.jenkins.plugins.akeyless.synced.credentials.AkeylessSyncedCertificateCredentials;
+import io.jenkins.plugins.akeyless.synced.credentials.AkeylessSyncedFileCredentials;
+import io.jenkins.plugins.akeyless.synced.credentials.AkeylessSyncedSSHUserPrivateKeyCredentials;
+import io.jenkins.plugins.akeyless.synced.credentials.AkeylessSyncedStringCredentials;
+import io.jenkins.plugins.akeyless.synced.credentials.AkeylessSyncedUsernamePasswordCredentials;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Creates Jenkins credential instances from Akeyless item metadata (name, description, tags) and client for on-demand fetch.
+ */
+public final class SyncedCredentialsFactory {
+
+    private SyncedCredentialsFactory() {}
+
+    /**
+     * Create a Jenkins credential from an Akeyless item. Credentials do not store the API client
+     * so they remain serializable and safe for Jenkins class filter; the client is built on demand
+     * when the secret value is fetched.
+     * @param id Jenkins credential id (sanitized path, [a-zA-Z0-9_.-]+)
+     * @param akeylessPath full Akeyless path for getSecretValue API
+     * @param description optional description
+     * @param tags tags from Akeyless (e.g. jenkins:credentials:type, jenkins:credentials:username)
+     * @return credential if type is supported, empty otherwise
+     */
+    public static Optional<StandardCredentials> create(
+            String id,
+            String akeylessPath,
+            String description,
+            Map<String, String> tags) {
+        return create(id, akeylessPath, description, tags, null);
+    }
+
+    public static Optional<StandardCredentials> create(
+            String id,
+            String akeylessPath,
+            String description,
+            Map<String, String> tags,
+            @Nullable String ownerUserId) {
+        String type = tags.getOrDefault(SyncedCredentialTags.TYPE, SyncedCredentialType.STRING);
+        String username = tags.getOrDefault(SyncedCredentialTags.USERNAME, "");
+        String filename = tags.getOrDefault(SyncedCredentialTags.FILENAME, id);
+        String valueFormat = tags.getOrDefault(SyncedCredentialTags.VALUE_FORMAT, "").trim();
+
+        switch (type) {
+            case SyncedCredentialType.STRING:
+                return Optional.of(new AkeylessSyncedStringCredentials(id, akeylessPath, description, ownerUserId));
+            case SyncedCredentialType.USERNAME_PASSWORD:
+                return Optional.of(new AkeylessSyncedUsernamePasswordCredentials(id, akeylessPath, description, username, valueFormat, ownerUserId));
+            case SyncedCredentialType.SSH_USER_PRIVATE_KEY:
+                return Optional.of(new AkeylessSyncedSSHUserPrivateKeyCredentials(id, akeylessPath, description, username, valueFormat, ownerUserId));
+            case SyncedCredentialType.CERTIFICATE:
+                return Optional.of(new AkeylessSyncedCertificateCredentials(id, akeylessPath, description, ownerUserId));
+            case SyncedCredentialType.FILE:
+                return Optional.of(new AkeylessSyncedFileCredentials(id, akeylessPath, description, filename, ownerUserId));
+            default:
+                return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/factory/SyncedCredentialsFactory.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/factory/SyncedCredentialsFactory.java
@@ -6,10 +6,9 @@ import io.jenkins.plugins.akeyless.synced.credentials.AkeylessSyncedFileCredenti
 import io.jenkins.plugins.akeyless.synced.credentials.AkeylessSyncedSSHUserPrivateKeyCredentials;
 import io.jenkins.plugins.akeyless.synced.credentials.AkeylessSyncedStringCredentials;
 import io.jenkins.plugins.akeyless.synced.credentials.AkeylessSyncedUsernamePasswordCredentials;
-
-import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * Creates Jenkins credential instances from Akeyless item metadata (name, description, tags) and client for on-demand fetch.
@@ -29,10 +28,7 @@ public final class SyncedCredentialsFactory {
      * @return credential if type is supported, empty otherwise
      */
     public static Optional<StandardCredentials> create(
-            String id,
-            String akeylessPath,
-            String description,
-            Map<String, String> tags) {
+            String id, String akeylessPath, String description, Map<String, String> tags) {
         return create(id, akeylessPath, description, tags, null);
     }
 
@@ -45,19 +41,24 @@ public final class SyncedCredentialsFactory {
         String type = tags.getOrDefault(SyncedCredentialTags.TYPE, SyncedCredentialType.STRING);
         String username = tags.getOrDefault(SyncedCredentialTags.USERNAME, "");
         String filename = tags.getOrDefault(SyncedCredentialTags.FILENAME, id);
-        String valueFormat = tags.getOrDefault(SyncedCredentialTags.VALUE_FORMAT, "").trim();
+        String valueFormat =
+                tags.getOrDefault(SyncedCredentialTags.VALUE_FORMAT, "").trim();
 
         switch (type) {
             case SyncedCredentialType.STRING:
                 return Optional.of(new AkeylessSyncedStringCredentials(id, akeylessPath, description, ownerUserId));
             case SyncedCredentialType.USERNAME_PASSWORD:
-                return Optional.of(new AkeylessSyncedUsernamePasswordCredentials(id, akeylessPath, description, username, valueFormat, ownerUserId));
+                return Optional.of(new AkeylessSyncedUsernamePasswordCredentials(
+                        id, akeylessPath, description, username, valueFormat, ownerUserId));
             case SyncedCredentialType.SSH_USER_PRIVATE_KEY:
-                return Optional.of(new AkeylessSyncedSSHUserPrivateKeyCredentials(id, akeylessPath, description, username, valueFormat, ownerUserId));
+                return Optional.of(new AkeylessSyncedSSHUserPrivateKeyCredentials(
+                        id, akeylessPath, description, username, valueFormat, ownerUserId));
             case SyncedCredentialType.CERTIFICATE:
-                return Optional.of(new AkeylessSyncedCertificateCredentials(id, akeylessPath, description, ownerUserId));
+                return Optional.of(
+                        new AkeylessSyncedCertificateCredentials(id, akeylessPath, description, ownerUserId));
             case SyncedCredentialType.FILE:
-                return Optional.of(new AkeylessSyncedFileCredentials(id, akeylessPath, description, filename, ownerUserId));
+                return Optional.of(
+                        new AkeylessSyncedFileCredentials(id, akeylessPath, description, filename, ownerUserId));
             default:
                 return Optional.empty();
         }

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/supplier/FolderListingCache.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/supplier/FolderListingCache.java
@@ -1,0 +1,106 @@
+package io.jenkins.plugins.akeyless.synced.supplier;
+
+import io.akeyless.client.ApiException;
+import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Caches recursive {@code list-items} results for folder-only discovery to avoid hammering Akeyless on every
+ * {@code CredentialsProvider#getCredentials} call.
+ */
+public final class FolderListingCache {
+
+    /** When caching is enabled, list-items results are reused for this many seconds (not user-configurable). */
+    /** Align with AWS Secrets Manager Credentials Provider cache wording/duration (5 minutes). */
+    public static final int DEFAULT_CACHE_TTL_SECONDS = 300;
+
+    private static final Logger LOG = Logger.getLogger(FolderListingCache.class.getName());
+
+    private static final Object LOCK = new Object();
+
+    @GuardedBy("LOCK")
+    private static volatile String cachedFolderKey;
+
+    @GuardedBy("LOCK")
+    private static volatile int cachedTtlSeconds;
+
+    @GuardedBy("LOCK")
+    private static volatile long cachedAtNanos;
+
+    @GuardedBy("LOCK")
+    private static volatile List<String> cachedPaths = Collections.emptyList();
+
+    private FolderListingCache() {}
+
+    /** Clears the cache (used when config changes materially). */
+    public static void invalidate() {
+        synchronized (LOCK) {
+            cachedFolderKey = null;
+            cachedTtlSeconds = 0;
+            cachedAtNanos = 0;
+            cachedPaths = Collections.emptyList();
+        }
+    }
+
+    /**
+     * Loads folder contents, using the in-memory cache when {@code cacheEnabled} is true.
+     */
+    @Nonnull
+    public static List<String> getOrLoad(
+            @Nonnull AkeylessSyncedClient client,
+            @Nonnull String folderNormalized,
+            boolean cacheEnabled,
+            @Nullable String ownerUserId) throws ApiException {
+        if (!cacheEnabled) {
+            return client.listSecretItemPathsRecursive(folderNormalized);
+        }
+
+        int ttlSec = DEFAULT_CACHE_TTL_SECONDS;
+        long ttlNanos = ttlSec * 1_000_000_000L;
+        String cacheKey = cacheKey(ownerUserId, folderNormalized);
+        synchronized (LOCK) {
+            long age = System.nanoTime() - cachedAtNanos;
+            if (cacheKey.equals(cachedFolderKey)
+                    && ttlSec == cachedTtlSeconds
+                    && cachedAtNanos != 0
+                    && age >= 0
+                    && age < ttlNanos) {
+                LOG.log(Level.FINE, "Akeyless Credentials Provider: list-items cache hit for folder={0} (TTL {1}s)",
+                        new Object[]{folderNormalized, ttlSec});
+                return new ArrayList<>(cachedPaths);
+            }
+        }
+
+        List<String> fresh = client.listSecretItemPathsRecursive(folderNormalized);
+        synchronized (LOCK) {
+            cachedFolderKey = cacheKey;
+            cachedTtlSeconds = ttlSec;
+            cachedPaths = Collections.unmodifiableList(new ArrayList<>(fresh));
+            cachedAtNanos = System.nanoTime();
+        }
+        LOG.log(Level.INFO, "Akeyless Credentials Provider: list-items refreshed for folder={0}, {1} path(s), cache TTL {2}s",
+                new Object[]{folderNormalized, fresh.size(), ttlSec});
+        return new ArrayList<>(fresh);
+    }
+
+    @Nonnull
+    public static List<String> getOrLoad(
+            @Nonnull AkeylessSyncedClient client,
+            @Nonnull String folderNormalized,
+            boolean cacheEnabled) throws ApiException {
+        return getOrLoad(client, folderNormalized, cacheEnabled, null);
+    }
+
+    private static String cacheKey(@Nullable String ownerUserId, String folderNormalized) {
+        String owner = ownerUserId != null && !ownerUserId.isBlank() ? ownerUserId : "@global";
+        return owner + "|" + folderNormalized;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/supplier/FolderListingCache.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/supplier/FolderListingCache.java
@@ -2,15 +2,14 @@ package io.jenkins.plugins.akeyless.synced.supplier;
 
 import io.akeyless.client.ApiException;
 import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.GuardedBy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 
 /**
  * Caches recursive {@code list-items} results for folder-only discovery to avoid hammering Akeyless on every
@@ -58,7 +57,8 @@ public final class FolderListingCache {
             @Nonnull AkeylessSyncedClient client,
             @Nonnull String folderNormalized,
             boolean cacheEnabled,
-            @Nullable String ownerUserId) throws ApiException {
+            @Nullable String ownerUserId)
+            throws ApiException {
         if (!cacheEnabled) {
             return client.listSecretItemPathsRecursive(folderNormalized);
         }
@@ -73,8 +73,10 @@ public final class FolderListingCache {
                     && cachedAtNanos != 0
                     && age >= 0
                     && age < ttlNanos) {
-                LOG.log(Level.FINE, "Akeyless Credentials Provider: list-items cache hit for folder={0} (TTL {1}s)",
-                        new Object[]{folderNormalized, ttlSec});
+                LOG.log(
+                        Level.FINE,
+                        "Akeyless Credentials Provider: list-items cache hit for folder={0} (TTL {1}s)",
+                        new Object[] {folderNormalized, ttlSec});
                 return new ArrayList<>(cachedPaths);
             }
         }
@@ -86,16 +88,17 @@ public final class FolderListingCache {
             cachedPaths = Collections.unmodifiableList(new ArrayList<>(fresh));
             cachedAtNanos = System.nanoTime();
         }
-        LOG.log(Level.INFO, "Akeyless Credentials Provider: list-items refreshed for folder={0}, {1} path(s), cache TTL {2}s",
-                new Object[]{folderNormalized, fresh.size(), ttlSec});
+        LOG.log(
+                Level.INFO,
+                "Akeyless Credentials Provider: list-items refreshed for folder={0}, {1} path(s), cache TTL {2}s",
+                new Object[] {folderNormalized, fresh.size(), ttlSec});
         return new ArrayList<>(fresh);
     }
 
     @Nonnull
     public static List<String> getOrLoad(
-            @Nonnull AkeylessSyncedClient client,
-            @Nonnull String folderNormalized,
-            boolean cacheEnabled) throws ApiException {
+            @Nonnull AkeylessSyncedClient client, @Nonnull String folderNormalized, boolean cacheEnabled)
+            throws ApiException {
         return getOrLoad(client, folderNormalized, cacheEnabled, null);
     }
 

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/supplier/SyncedCredentialsSupplier.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/supplier/SyncedCredentialsSupplier.java
@@ -2,23 +2,21 @@ package io.jenkins.plugins.akeyless.synced.supplier;
 
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import hudson.model.User;
+import io.akeyless.client.ApiException;
 import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedAuthResolver;
 import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient;
 import io.jenkins.plugins.akeyless.synced.config.AkeylessSyncedCredentialsProviderConfig;
 import io.jenkins.plugins.akeyless.synced.config.AkeylessSyncedUserAuthProperty;
 import io.jenkins.plugins.akeyless.synced.config.FolderPathRules;
-import io.jenkins.plugins.akeyless.synced.factory.SyncedCredentialsFactory;
 import io.jenkins.plugins.akeyless.synced.factory.SyncedCredentialTags;
 import io.jenkins.plugins.akeyless.synced.factory.SyncedCredentialType;
-
-import io.akeyless.client.ApiException;
-
+import io.jenkins.plugins.akeyless.synced.factory.SyncedCredentialsFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
@@ -40,7 +38,8 @@ public class SyncedCredentialsSupplier {
         return get(config, null);
     }
 
-    public static Collection<StandardCredentials> get(AkeylessSyncedCredentialsProviderConfig config, @Nullable User user) {
+    public static Collection<StandardCredentials> get(
+            AkeylessSyncedCredentialsProviderConfig config, @Nullable User user) {
         if (config == null || !config.isDiscoveryConfigured()) {
             LOG.log(Level.INFO, "Akeyless Credentials Provider: not configured (URL and secret paths required)");
             return Collections.emptyList();
@@ -52,7 +51,9 @@ public class SyncedCredentialsSupplier {
             }
             AkeylessSyncedUserAuthProperty auth = user.getProperty(AkeylessSyncedUserAuthProperty.class);
             if (auth == null || !auth.isConfigured()) {
-                LOG.log(Level.FINE, "Akeyless Credentials Provider: user {0} has no Akeyless authentication configured",
+                LOG.log(
+                        Level.FINE,
+                        "Akeyless Credentials Provider: user {0} has no Akeyless authentication configured",
                         user.getId());
                 return Collections.emptyList();
             }
@@ -65,13 +66,13 @@ public class SyncedCredentialsSupplier {
         String secretNamesInput = config.getSecretNames();
         String secretPathsInput = config.getSecretPaths();
         boolean hasSecretPaths = secretPathsInput != null && !secretPathsInput.isBlank();
-        boolean hasFolderAndNames = folderPath != null && !folderPath.isBlank()
-                && secretNamesInput != null && !secretNamesInput.isBlank();
-        boolean hasFolderOnly = folderPath != null && !folderPath.isBlank()
-                && !hasFolderAndNames
-                && !hasSecretPaths;
+        boolean hasFolderAndNames =
+                folderPath != null && !folderPath.isBlank() && secretNamesInput != null && !secretNamesInput.isBlank();
+        boolean hasFolderOnly = folderPath != null && !folderPath.isBlank() && !hasFolderAndNames && !hasSecretPaths;
         if (!hasFolderAndNames && !hasSecretPaths && !hasFolderOnly) {
-            LOG.log(Level.INFO, "Akeyless Credentials Provider: set ''Folder path'' alone (discover secrets under the folder), or ''Folder path'' + ''Secret names'', or ''Secret paths'', in Manage Jenkins → Configure System.");
+            LOG.log(
+                    Level.INFO,
+                    "Akeyless Credentials Provider: set ''Folder path'' alone (discover secrets under the folder), or ''Folder path'' + ''Secret names'', or ''Secret paths'', in Manage Jenkins → Configure System.");
             return Collections.emptyList();
         }
         try {
@@ -84,14 +85,16 @@ public class SyncedCredentialsSupplier {
             Collection<StandardCredentials> result = new ArrayList<>();
             Set<String> usedCredentialIds = new HashSet<>();
 
-            // 0) Folder path only: list-items under the folder (recursive) — credential id is usually the last path segment.
+            // 0) Folder path only: list-items under the folder (recursive) — credential id is usually the last path
+            // segment.
             if (hasFolderOnly) {
                 String folderNorm = folderPath.trim().replaceAll("/+$", "");
                 if (!folderNorm.startsWith("/")) {
                     folderNorm = "/" + folderNorm;
                 }
                 if (FolderPathRules.isForbiddenRootFolder(folderNorm)) {
-                    LOG.log(Level.WARNING,
+                    LOG.log(
+                            Level.WARNING,
                             "Akeyless Credentials Provider: folder path is root ''/'' only — discovery disabled. Set a subfolder (e.g. /CICD/secrets).");
                     return result;
                 }
@@ -102,11 +105,15 @@ public class SyncedCredentialsSupplier {
                         Map<String, String> tags = resolveTagsFromAkeyless(client, fullPath);
                         addOneCredentialForPath(result, usedCredentialIds, fullPath, tags, ownerUserId);
                     }
-                    LOG.log(Level.INFO, "Akeyless Credentials Provider: folder-only discovery found {0} item path(s) under {1}",
-                            new Object[]{discovered.size(), folderNorm});
+                    LOG.log(
+                            Level.INFO,
+                            "Akeyless Credentials Provider: folder-only discovery found {0} item path(s) under {1}",
+                            new Object[] {discovered.size(), folderNorm});
                 } catch (ApiException e) {
-                    LOG.log(Level.WARNING, "Akeyless Credentials Provider: list-items under folder={0} failed: {1}",
-                            new Object[]{folderNorm, e.getMessage()});
+                    LOG.log(
+                            Level.WARNING,
+                            "Akeyless Credentials Provider: list-items under folder={0} failed: {1}",
+                            new Object[] {folderNorm, e.getMessage()});
                 }
             }
 
@@ -118,7 +125,8 @@ public class SyncedCredentialsSupplier {
                     folderNorm = "/" + folderNorm;
                 }
                 if (FolderPathRules.isForbiddenRootFolder(folderNorm)) {
-                    LOG.log(Level.WARNING,
+                    LOG.log(
+                            Level.WARNING,
                             "Akeyless Credentials Provider: folder path is root ''/'' only — cannot resolve secrets under folder. Configure a subfolder.");
                     return result;
                 }
@@ -126,11 +134,13 @@ public class SyncedCredentialsSupplier {
                 for (String raw : names) {
                     String name = raw.trim();
                     if (name.isEmpty()) continue;
-                    String fullPath = folderNorm + "/" + name.replaceAll("^/+", "");  // e.g. /CICD/jenkins/test/test3/jenkinsai
+                    String fullPath =
+                            folderNorm + "/" + name.replaceAll("^/+", ""); // e.g. /CICD/jenkins/test/test3/jenkinsai
                     Map<String, String> tags = resolveTagsFromAkeyless(client, fullPath);
                     addOneCredentialForPath(result, usedCredentialIds, fullPath, tags, ownerUserId);
-                    LOG.log(Level.INFO, "Akeyless Credentials Provider: folder+name path={0} type={1}",
-                            new Object[]{fullPath, tags.getOrDefault(SyncedCredentialTags.TYPE, SyncedCredentialType.STRING)});
+                    LOG.log(Level.INFO, "Akeyless Credentials Provider: folder+name path={0} type={1}", new Object[] {
+                        fullPath, tags.getOrDefault(SyncedCredentialTags.TYPE, SyncedCredentialType.STRING)
+                    });
                 }
             }
 
@@ -149,7 +159,9 @@ public class SyncedCredentialsSupplier {
             if (!result.isEmpty()) {
                 Set<String> ids = new HashSet<>();
                 for (StandardCredentials c : result) ids.add(c.getId());
-                LOG.log(Level.INFO, "Akeyless Credentials Provider: {0} credential(s), ids={1}", new Object[]{result.size(), ids});
+                LOG.log(Level.INFO, "Akeyless Credentials Provider: {0} credential(s), ids={1}", new Object[] {
+                    result.size(), ids
+                });
             }
             return result;
         } catch (Exception e) {
@@ -182,7 +194,8 @@ public class SyncedCredentialsSupplier {
             return;
         }
         usedCredentialIds.add(id);
-        SyncedCredentialsFactory.create(id, full, description, defaultTags, ownerUserId).ifPresent(result::add);
+        SyncedCredentialsFactory.create(id, full, description, defaultTags, ownerUserId)
+                .ifPresent(result::add);
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/akeyless/synced/supplier/SyncedCredentialsSupplier.java
+++ b/src/main/java/io/jenkins/plugins/akeyless/synced/supplier/SyncedCredentialsSupplier.java
@@ -1,0 +1,220 @@
+package io.jenkins.plugins.akeyless.synced.supplier;
+
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import hudson.model.User;
+import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedAuthResolver;
+import io.jenkins.plugins.akeyless.synced.client.AkeylessSyncedClient;
+import io.jenkins.plugins.akeyless.synced.config.AkeylessSyncedCredentialsProviderConfig;
+import io.jenkins.plugins.akeyless.synced.config.AkeylessSyncedUserAuthProperty;
+import io.jenkins.plugins.akeyless.synced.config.FolderPathRules;
+import io.jenkins.plugins.akeyless.synced.factory.SyncedCredentialsFactory;
+import io.jenkins.plugins.akeyless.synced.factory.SyncedCredentialTags;
+import io.jenkins.plugins.akeyless.synced.factory.SyncedCredentialType;
+
+import io.akeyless.client.ApiException;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+
+/**
+ * Supplies credentials from user-configured paths. Uses {@code describe-item} to read Akeyless item tags
+ * (same convention as AWS Secrets Manager Credentials Provider). Secret values are fetched on demand via
+ * {@code describe-item} then the appropriate API (static / dynamic / rotated / certificate) per item type.
+ */
+public class SyncedCredentialsSupplier {
+
+    private static final Logger LOG = Logger.getLogger(SyncedCredentialsSupplier.class.getName());
+    private static final Pattern PATH_SPLIT = Pattern.compile("[,\n\r]+");
+
+    public static Collection<StandardCredentials> get(AkeylessSyncedCredentialsProviderConfig config) {
+        return get(config, null);
+    }
+
+    public static Collection<StandardCredentials> get(AkeylessSyncedCredentialsProviderConfig config, @Nullable User user) {
+        if (config == null || !config.isDiscoveryConfigured()) {
+            LOG.log(Level.INFO, "Akeyless Credentials Provider: not configured (URL and secret paths required)");
+            return Collections.emptyList();
+        }
+        if (config.isPerUserAuthentication()) {
+            if (user == null) {
+                LOG.log(Level.FINE, "Akeyless Credentials Provider: per-user auth requires a Jenkins user");
+                return Collections.emptyList();
+            }
+            AkeylessSyncedUserAuthProperty auth = user.getProperty(AkeylessSyncedUserAuthProperty.class);
+            if (auth == null || !auth.isConfigured()) {
+                LOG.log(Level.FINE, "Akeyless Credentials Provider: user {0} has no Akeyless authentication configured",
+                        user.getId());
+                return Collections.emptyList();
+            }
+        } else if (!config.isConfigured()) {
+            LOG.log(Level.INFO, "Akeyless Credentials Provider: not configured (URL and auth required)");
+            return Collections.emptyList();
+        }
+        String ownerUserId = user != null ? user.getId() : null;
+        String folderPath = config.getFolderPath();
+        String secretNamesInput = config.getSecretNames();
+        String secretPathsInput = config.getSecretPaths();
+        boolean hasSecretPaths = secretPathsInput != null && !secretPathsInput.isBlank();
+        boolean hasFolderAndNames = folderPath != null && !folderPath.isBlank()
+                && secretNamesInput != null && !secretNamesInput.isBlank();
+        boolean hasFolderOnly = folderPath != null && !folderPath.isBlank()
+                && !hasFolderAndNames
+                && !hasSecretPaths;
+        if (!hasFolderAndNames && !hasSecretPaths && !hasFolderOnly) {
+            LOG.log(Level.INFO, "Akeyless Credentials Provider: set ''Folder path'' alone (discover secrets under the folder), or ''Folder path'' + ''Secret names'', or ''Secret paths'', in Manage Jenkins → Configure System.");
+            return Collections.emptyList();
+        }
+        try {
+            AkeylessSyncedClient client = AkeylessSyncedAuthResolver.resolveClient(ownerUserId);
+            if (client == null) {
+                LOG.log(Level.WARNING, "Akeyless Credentials Provider: could not build client (check URL and auth)");
+                return Collections.emptyList();
+            }
+
+            Collection<StandardCredentials> result = new ArrayList<>();
+            Set<String> usedCredentialIds = new HashSet<>();
+
+            // 0) Folder path only: list-items under the folder (recursive) — credential id is usually the last path segment.
+            if (hasFolderOnly) {
+                String folderNorm = folderPath.trim().replaceAll("/+$", "");
+                if (!folderNorm.startsWith("/")) {
+                    folderNorm = "/" + folderNorm;
+                }
+                if (FolderPathRules.isForbiddenRootFolder(folderNorm)) {
+                    LOG.log(Level.WARNING,
+                            "Akeyless Credentials Provider: folder path is root ''/'' only — discovery disabled. Set a subfolder (e.g. /CICD/secrets).");
+                    return result;
+                }
+                try {
+                    List<String> discovered =
+                            FolderListingCache.getOrLoad(client, folderNorm, config.isCache(), ownerUserId);
+                    for (String fullPath : discovered) {
+                        Map<String, String> tags = resolveTagsFromAkeyless(client, fullPath);
+                        addOneCredentialForPath(result, usedCredentialIds, fullPath, tags, ownerUserId);
+                    }
+                    LOG.log(Level.INFO, "Akeyless Credentials Provider: folder-only discovery found {0} item path(s) under {1}",
+                            new Object[]{discovered.size(), folderNorm});
+                } catch (ApiException e) {
+                    LOG.log(Level.WARNING, "Akeyless Credentials Provider: list-items under folder={0} failed: {1}",
+                            new Object[]{folderNorm, e.getMessage()});
+                }
+            }
+
+            // 1) Folder path + secret names: full path = folderPath + "/" + secretName.
+            //    Secret name is the credential id used in the pipeline (e.g. credentials('jenkinsai')).
+            if (hasFolderAndNames) {
+                String folderNorm = folderPath.trim().replaceAll("/+$", "");
+                if (!folderNorm.startsWith("/")) {
+                    folderNorm = "/" + folderNorm;
+                }
+                if (FolderPathRules.isForbiddenRootFolder(folderNorm)) {
+                    LOG.log(Level.WARNING,
+                            "Akeyless Credentials Provider: folder path is root ''/'' only — cannot resolve secrets under folder. Configure a subfolder.");
+                    return result;
+                }
+                String[] names = PATH_SPLIT.split(secretNamesInput);
+                for (String raw : names) {
+                    String name = raw.trim();
+                    if (name.isEmpty()) continue;
+                    String fullPath = folderNorm + "/" + name.replaceAll("^/+", "");  // e.g. /CICD/jenkins/test/test3/jenkinsai
+                    Map<String, String> tags = resolveTagsFromAkeyless(client, fullPath);
+                    addOneCredentialForPath(result, usedCredentialIds, fullPath, tags, ownerUserId);
+                    LOG.log(Level.INFO, "Akeyless Credentials Provider: folder+name path={0} type={1}",
+                            new Object[]{fullPath, tags.getOrDefault(SyncedCredentialTags.TYPE, SyncedCredentialType.STRING)});
+                }
+            }
+
+            // 2) Explicit full secret paths (and pathPrefix fallback)
+            if (hasSecretPaths) {
+                String[] rawPaths = PATH_SPLIT.split(secretPathsInput);
+                for (String raw : rawPaths) {
+                    String path = raw.trim();
+                    if (path.isEmpty()) continue;
+                    String akeylessPath = path.startsWith("/") ? path : "/" + path;
+                    Map<String, String> tags = resolveTagsFromAkeyless(client, akeylessPath);
+                    addOneCredentialForPath(result, usedCredentialIds, akeylessPath, tags, ownerUserId);
+                }
+            }
+
+            if (!result.isEmpty()) {
+                Set<String> ids = new HashSet<>();
+                for (StandardCredentials c : result) ids.add(c.getId());
+                LOG.log(Level.INFO, "Akeyless Credentials Provider: {0} credential(s), ids={1}", new Object[]{result.size(), ids});
+            }
+            return result;
+        } catch (Exception e) {
+            LOG.log(Level.WARNING, "Error loading Akeyless credentials", e);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * One Jenkins credential per Akeyless path. Credential id is the last path segment (e.g. {@code jenkinsai}) when
+     * that id is not already taken; otherwise the full normalized path (e.g. when two secrets share the same name
+     * under different folders).
+     */
+    private static void addOneCredentialForPath(
+            Collection<StandardCredentials> result,
+            Set<String> usedCredentialIds,
+            String akeylessPath,
+            Map<String, String> defaultTags,
+            @Nullable String ownerUserId) {
+        String full = AkeylessSyncedClient.normalizeItemPath(akeylessPath);
+        String description = full;
+        String lastSeg = lastPathSegment(full);
+        String id;
+        if (lastSeg != null && !usedCredentialIds.contains(lastSeg)) {
+            id = lastSeg;
+        } else if (!usedCredentialIds.contains(full)) {
+            id = full;
+        } else {
+            LOG.log(Level.FINE, "Akeyless Credentials Provider: skip duplicate path {0}", full);
+            return;
+        }
+        usedCredentialIds.add(id);
+        SyncedCredentialsFactory.create(id, full, description, defaultTags, ownerUserId).ifPresent(result::add);
+    }
+
+    /**
+     * Loads tags from Akeyless ({@code describe-item}) and merges with defaults (same keys as AWS Secrets Manager plugin).
+     * If describe-item fails or returns no type tag, defaults to {@link SyncedCredentialType#STRING}.
+     */
+    private static Map<String, String> resolveTagsFromAkeyless(AkeylessSyncedClient client, String fullPath) {
+        Map<String, String> tags = new HashMap<>(client.getItemTags(fullPath));
+        tags.putIfAbsent(SyncedCredentialTags.TYPE, SyncedCredentialType.STRING);
+        return tags;
+    }
+
+    /**
+     * Credential ID from path: strips leading/trailing slashes and sanitizes to [a-zA-Z0-9/_.-].
+     */
+    private static String credentialIdFromPath(String path) {
+        if (path == null || path.isEmpty()) return null;
+        String trimmed = path.replaceAll("^/+|/+$", "");
+        if (trimmed.isEmpty()) return null;
+        if (!trimmed.matches("[a-zA-Z0-9/_.-]+")) {
+            trimmed = trimmed.replaceAll("[^a-zA-Z0-9/_.-]", "_");
+        }
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    /** Last segment of path (e.g. /CICD/jenkins/test/test3/jenkinsai → jenkinsai) for use as short credential ID. */
+    private static String lastPathSegment(String path) {
+        if (path == null || path.isEmpty()) return null;
+        String trimmed = path.replaceAll("/+$", "").trim();
+        int last = trimmed.lastIndexOf('/');
+        if (last < 0) return credentialIdFromPath(trimmed);
+        String segment = trimmed.substring(last + 1);
+        return segment.isEmpty() ? null : credentialIdFromPath(segment);
+    }
+}

--- a/src/main/resources/images/symbols/akeyless.svg
+++ b/src/main/resources/images/symbols/akeyless.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+  <!-- Secrets / vault motif: shield + keyhole; uses currentColor for Jenkins theming -->
+  <path fill="none" stroke="currentColor" stroke-width="1.75" stroke-linejoin="round"
+        d="M12 22s8-4 8-10V6l-8-3.5L4 6v6c0 6 8 10 8 10z"/>
+  <path fill="currentColor" stroke="none"
+        d="M12 9.2c-1 0-1.8.8-1.8 1.8 0 .7.4 1.3.9 1.6v1.9h1.8v-1.9c.5-.3.9-.9.9-1.6 0-1-.8-1.8-1.8-1.8zm0 6.5a.85.85 0 100 1.7.85.85 0 000-1.7z"/>
+</svg>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,7 @@
 <?jelly escape-by-default='true'?>
-<div>Plugin to fetch secrets and certificates from
-    <a href="https://www.akeyless.io/">Akeyless</a> platform
+<div>
+    Fetch secrets and certificates from
+    <a href="https://www.akeyless.io/">Akeyless</a>.
+    Supports classic job binding (<code>withAkeyless</code> / Build Wrapper) and optional
+    Credentials Provider sync for native <code>credentials('id')</code> usage.
 </div>

--- a/src/main/resources/io/jenkins/plugins/akeyless/synced/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/akeyless/synced/Messages.properties
@@ -1,0 +1,11 @@
+AkeylessSyncedCredentialsProvider_DisplayName=Akeyless
+
+# Config section (Manage Jenkins → Configure System)
+AkeylessCredentialsProvider_SectionTitle=Akeyless Credentials Provider
+AkeylessCredentialsProvider_AkeylessUrl=Akeyless URL
+AkeylessCredentialsProvider_AkeylessUrlDescription=Akeyless gateway URL including /api/v2 (e.g. https://my-gateway.akeyless.io/api/v2)
+AkeylessCredentialsProvider_AkeylessAuthentication=Akeyless authentication
+AkeylessCredentialsProvider_AkeylessAuthenticationDescription=Select a credential that authenticates to Akeyless (API Key, AWS IAM, Azure, GCP, K8s, Universal Identity, Certificate, or Email from the Akeyless plugin).
+AkeylessCredentialsProvider_PathPrefix=Path prefix (optional)
+AkeylessCredentialsProvider_PathPrefixDescription=Only list static secrets under this path (e.g. /jenkins/prod).
+AkeylessCredentialsProvider_SkipSslVerification=Skip SSL verification

--- a/src/main/resources/io/jenkins/plugins/akeyless/synced/auth/ApiKeySyncedAuthMethod/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/akeyless/synced/auth/ApiKeySyncedAuthMethod/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry title="Access Key" field="accessKey" description="The Akeyless access key secret (stored encrypted). Do not paste your Access ID here.">
+    <f:password/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/akeyless/synced/auth/AwsIamSyncedAuthMethod/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/akeyless/synced/auth/AwsIamSyncedAuthMethod/config.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:description>AWS IAM credentials are auto-detected from the environment (EC2 instance profile, ECS task role, or AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY environment variables).</f:description>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/akeyless/synced/auth/AzureAdSyncedAuthMethod/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/akeyless/synced/auth/AzureAdSyncedAuthMethod/config.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:description>Azure AD identity is auto-detected from the Azure Instance Metadata Service (IMDS). Ensure Jenkins runs on an Azure VM/VMSS with a managed identity assigned.</f:description>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/akeyless/synced/auth/CertificateSyncedAuthMethod/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/akeyless/synced/auth/CertificateSyncedAuthMethod/config.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry title="Certificate Data (PEM)" field="certData" description="Client certificate in PEM format (stored encrypted)">
+    <f:password/>
+  </f:entry>
+  <f:entry title="Private Key Data (PEM)" field="keyData" description="Client private key in PEM format (stored encrypted)">
+    <f:password/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/akeyless/synced/auth/EmailSyncedAuthMethod/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/akeyless/synced/auth/EmailSyncedAuthMethod/config.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry title="Email" field="adminEmail" description="Akeyless admin email address">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="Password" field="adminPassword" description="Akeyless admin password (stored encrypted)">
+    <f:password/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/akeyless/synced/auth/GcpSyncedAuthMethod/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/akeyless/synced/auth/GcpSyncedAuthMethod/config.jelly
@@ -1,0 +1,7 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry title="GCP Audience (optional)" field="gcpAudience" description="Override the audience for the GCP identity token. Defaults to 'akeyless.io'.">
+    <f:textbox placeholder="akeyless.io"/>
+  </f:entry>
+  <f:description>GCP identity is auto-detected from the GCP metadata service. Ensure Jenkins runs on a GCE/GKE instance with a service account.</f:description>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/akeyless/synced/auth/KubernetesSyncedAuthMethod/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/akeyless/synced/auth/KubernetesSyncedAuthMethod/config.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry title="K8s Auth Config Name" field="k8sAuthConfigName" description="Akeyless Kubernetes authentication configuration name">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="Service Account Token (optional)" field="k8sServiceAccountToken" description="Kubernetes service account token. Leave empty to auto-read from the pod mount (/var/run/secrets/kubernetes.io/serviceaccount/token).">
+    <f:textbox/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/akeyless/synced/auth/UniversalIdentitySyncedAuthMethod/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/akeyless/synced/auth/UniversalIdentitySyncedAuthMethod/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry title="UID Token" field="uidToken" description="Akeyless Universal Identity token (stored encrypted)">
+    <f:password/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/akeyless/synced/config/AkeylessSyncedCredentialsProviderConfig/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/akeyless/synced/config/AkeylessSyncedCredentialsProviderConfig/config.jelly
@@ -1,0 +1,32 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+  <f:section title="Akeyless Synced Credentials (Credentials Provider)" name="akeyless-synced-credentials-provider">
+    <f:description>
+      Optional. When configured, Akeyless items appear as native Jenkins credentials for use with
+      <code>credentials('id')</code> / <code>withCredentials</code>. Existing Akeyless Plugin job binding
+      (<code>withAkeyless</code> / Build Wrapper) is unchanged and does not require this section.
+    </f:description>
+    <f:entry title="Akeyless URL" field="akeylessUrl" description="Your Akeyless gateway API URL (used as-is; no suffix is added). If behind a load balancer, use the full URL including path (e.g. https&#58;//gateway.example.com/api/v2).">
+      <f:textbox placeholder="https://my-gateway.akeyless.io or https://my-gateway.akeyless.io/api/v2"/>
+    </f:entry>
+    <f:dropdownDescriptorSelector title="Authentication scope" field="authenticationScopeMode" descriptors="${descriptor.getAuthenticationScopeDescriptors()}" description="Global: one Akeyless identity for all Jenkins users (configured below). Per user: each Jenkins user configures their own Akeyless auth on their profile (People → user → Configure). Works with a single Jenkins account too — that user configures Akeyless on their own profile."/>
+    <f:optionalBlock title="Global Akeyless authentication" inline="true" checked="${!instance.perUserAuthentication}">
+      <f:entry title="Access ID" field="accessId" description="Akeyless access ID (e.g. p-abc123). Required for all auth methods except Email.">
+        <f:textbox/>
+      </f:entry>
+      <f:dropdownDescriptorSelector title="Authentication Method" field="authMethod" descriptors="${descriptor.getAuthMethodDescriptors()}"/>
+    </f:optionalBlock>
+    <f:entry title="Cache" field="cache" description="When the cache is enabled, credentials are cached for 5 minutes.">
+      <f:checkbox default="true"/>
+    </f:entry>
+    <f:entry title="Folder path" field="folderPath" description="Folder in Akeyless (e.g. /CICD/jenkins/secrets). Cannot be ''/'' alone (entire vault). If you leave Secret names and Secret paths empty, items are discovered under this folder via list-items (recursive) when Cache is on. Otherwise combine folder + Secret names or use Secret paths alone.">
+      <f:textbox placeholder="/CICD/jenkins/test/test3"/>
+    </f:entry>
+    <f:entry title="Secret names" field="secretNames" description="Optional when folder-only discovery is used. Otherwise one name per line (e.g. jenkinsai). In the job use credentials('jenkinsai'). Full path = folder + '/' + name.">
+      <f:textarea placeholder="jenkinsai"/>
+    </f:entry>
+    <f:entry title="Secret paths (optional)" field="secretPaths" description="Only for full paths (e.g. /other/apikey). Do not put the folder path here — use Folder path + Secret names above for that.">
+      <f:textarea placeholder="/CICD/jenkins/other/apikey"/>
+    </f:entry>
+  </f:section>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/akeyless/synced/config/AkeylessSyncedUserAuthProperty/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/akeyless/synced/config/AkeylessSyncedUserAuthProperty/config.jelly
@@ -1,0 +1,7 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry title="Access ID" field="accessId" description="Your Akeyless access ID. Required for all auth methods except Email.">
+    <f:textbox/>
+  </f:entry>
+  <f:dropdownDescriptorSelector title="Authentication Method" field="authMethod" descriptors="${descriptor.getAuthMethodDescriptors()}"/>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/akeyless/synced/config/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/akeyless/synced/config/Messages.properties
@@ -1,0 +1,9 @@
+# Akeyless Credentials Provider - Configure System section
+AkeylessCredentialsProvider_SectionTitle=Akeyless Credentials Provider
+AkeylessCredentialsProvider_AkeylessUrl=Akeyless URL
+AkeylessCredentialsProvider_AkeylessUrlDescription=Akeyless gateway URL including /api/v2 (e.g. https://my-gateway.akeyless.io/api/v2)
+AkeylessCredentialsProvider_AkeylessAuthentication=Akeyless authentication
+AkeylessCredentialsProvider_AkeylessAuthenticationDescription=Select a credential that authenticates to Akeyless (API Key, AWS IAM, Azure, GCP, K8s, Universal Identity, Certificate, or Email from the Akeyless plugin).
+AkeylessCredentialsProvider_PathPrefix=Path prefix (optional)
+AkeylessCredentialsProvider_PathPrefixDescription=Only list static secrets under this path (e.g. /jenkins/prod).
+AkeylessCredentialsProvider_SkipSslVerification=Skip SSL verification


### PR DESCRIPTION
## Summary
- Adds an **optional** Akeyless synced Credentials Provider so secrets can appear as native Jenkins credentials for `credentials('id')` / `withCredentials`, similar to AWS Secrets Manager Credentials Provider.
- Classic Build Wrapper / `withAkeyless` flows are unchanged when the new **Akeyless Synced Credentials** system config section is left empty.
- Sync path uses Jenkins HTTP Proxy Configuration (`JenkinsProxyOkHttp`), supports folder discovery / explicit secret paths, tag-mapped credential types, and GLOBAL vs PER_USER auth scope.

## Test plan
- [x] Install the HPI (or build from this branch) and leave Synced Credentials empty — confirm existing freestyle / `withAkeyless` jobs still work.
- [x] Configure Synced Credentials (URL, auth, folder or secret paths), save, and confirm items appear under Credentials.
- [x] Pipeline with `credentials('id')` / `withCredentials` resolves synced secrets successfully.
- [x] Confirm Jenkins system HTTP proxy is honored for Akeyless API calls when configured.
- [x] Confirm classic binding and synced credentials can both be used on the same controller.

Refs discussion about consolidating into the existing plugin rather than a second Akeyless plugin (jenkins-infra/repository-permissions-updater#5156).


Made with [Cursor](https://cursor.com)