### PR TITLE
Bump akeyless-java to 5.0.31 for agentic_rules compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>io.akeyless</groupId>
       <artifactId>akeyless-java</artifactId>
-      <version>5.0.8</version>
+      <version>5.0.31</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
## Summary
- Bumps the embedded `akeyless-java` client from `5.0.8` to `5.0.31`.
- Fixes dynamic secret retrieval failing on `describeItem` when the API returns the newer `agentic_rules` field on `ItemGeneralInfo`.
- Older SDK uses strict JSON validation and throws: `The field agentic_rules in the JSON string is not defined in the ItemGeneralInfo properties`.

## Test plan
- [x] Build plugin locally (`mvn clean package -DskipTests`) and confirm `akeyless-java-5.0.31.jar` is bundled in the `.hpi`
- [x] Upload/install the local `.hpi` on a Jenkins instance
- [x] Fetch a dynamic secret (e.g. Postgres producer) that includes `agentic_rules` in `describe-item`
- [x] Confirm job succeeds past `describeItem` and injects credentials
- [ ] Smoke-test static and rotated secret retrieval still works


Made with [Cursor](https://cursor.com)